### PR TITLE
perf: Try to optimize for binary size

### DIFF
--- a/crates/anstyle-roff/tests/test_roff.rs
+++ b/crates/anstyle-roff/tests/test_roff.rs
@@ -1,11 +1,11 @@
-use anstyle::{AnsiColor, Color, Style};
+use anstyle::Style;
 
 #[test]
 fn test_ansi_color_output() {
-    let style = Style::new()
-        .fg_color(Some(Color::Ansi(AnsiColor::Red)))
-        .bg_color(Some(Color::Ansi(AnsiColor::Blue)));
-    let text = format!("{}{}", style.render(), "test");
+    // HACK: cansi doesn't properly merge separate sequences
+    // let style = AnsiColor::Red.on(AnsiColor::Blue);
+    // let text = format!("{}{}", style.render(), "test");
+    let text = "\u{1b}[31;44mtest".to_owned();
     let roff_doc = anstyle_roff::to_roff(&text);
     snapbox::assert_eq_path("tests/roffs/ansi_color.roff", roff_doc.to_roff());
 }
@@ -14,6 +14,7 @@ fn test_ansi_color_output() {
 fn test_bold_output() {
     let style = Style::new().bold();
     let text = format!("{}{}", style.render(), "test");
+    dbg!(&text);
     let roff_doc = anstyle_roff::to_roff(&text);
 
     snapbox::assert_eq_path("tests/roffs/bold.roff", roff_doc.to_roff());
@@ -23,6 +24,7 @@ fn test_bold_output() {
 fn test_italic_output() {
     let style = Style::new().italic();
     let text = format!("{}{}", style.render(), "test");
+    dbg!(&text);
 
     let roff_doc = anstyle_roff::to_roff(&text);
     snapbox::assert_eq_path("tests/roffs/italic.roff", roff_doc.to_roff());
@@ -30,10 +32,11 @@ fn test_italic_output() {
 
 #[test]
 fn test_bright_color_output_as_bold() {
-    let style = Style::new()
-        .fg_color(Some(Color::Ansi(AnsiColor::BrightRed)))
-        .bg_color(Some(Color::Ansi(AnsiColor::Blue)));
-    let text = format!("{}{}", style.render(), "test");
+    // HACK: cansi doesn't properly merge separate sequences
+    // let style = AnsiColor::BrightRed.on(AnsiColor::Blue);
+    // let text = format!("{}{}", style.render(), "test");
+    let text = "\u{1b}[91;44mtest".to_owned();
+    dbg!(&text);
     let roff_doc = anstyle_roff::to_roff(&text);
     snapbox::assert_eq_path("tests/roffs/bright_ansi_colors.roff", roff_doc.to_roff());
 }

--- a/crates/anstyle/src/color.rs
+++ b/crates/anstyle/src/color.rs
@@ -40,6 +40,14 @@ impl Color {
     }
 
     #[inline]
+    pub(crate) fn render_underline(self) -> impl core::fmt::Display {
+        DisplayColor {
+            color: self,
+            context: ColorContext::Underline,
+        }
+    }
+
+    #[inline]
     pub(crate) fn ansi_fmt(
         &self,
         f: &mut dyn core::fmt::Write,

--- a/crates/anstyle/src/effect.rs
+++ b/crates/anstyle/src/effect.rs
@@ -244,92 +244,68 @@ impl core::ops::SubAssign for Effects {
 
 pub(crate) struct Metadata {
     pub(crate) name: &'static str,
-    pub(crate) primary: usize,
-    pub(crate) secondary: Option<usize>,
+    pub(crate) escape: &'static str,
 }
 
 pub(crate) const METADATA: [Metadata; 12] = [
     Metadata {
         name: "BOLD",
-        primary: 1,
-        secondary: None,
+        escape: escape!("1"),
     },
     Metadata {
         name: "DIMMED",
-        primary: 2,
-        secondary: None,
+        escape: escape!("2"),
     },
     Metadata {
         name: "ITALIC",
-        primary: 3,
-        secondary: None,
+        escape: escape!("3"),
     },
     Metadata {
         name: "UNDERLINE",
-        primary: 4,
-        secondary: None,
+        escape: escape!("4"),
     },
     Metadata {
         name: "DOUBLE_UNDERLINE",
-        primary: 21,
-        secondary: None,
+        escape: escape!("21"),
     },
     Metadata {
         name: "CURLY_UNDERLINE",
-        primary: 4,
-        secondary: Some(3),
+        escape: escape!("4:3"),
     },
     Metadata {
         name: "DOTTED_UNDERLINE",
-        primary: 4,
-        secondary: Some(4),
+        escape: escape!("4:4"),
     },
     Metadata {
         name: "DASHED_UNDERLINE",
-        primary: 4,
-        secondary: Some(5),
+        escape: escape!("4:5"),
     },
     Metadata {
         name: "BLINK",
-        primary: 5,
-        secondary: None,
+        escape: escape!("5"),
     },
     Metadata {
         name: "INVERT",
-        primary: 7,
-        secondary: None,
+        escape: escape!("7"),
     },
     Metadata {
         name: "HIDDEN",
-        primary: 8,
-        secondary: None,
+        escape: escape!("8"),
     },
     Metadata {
         name: "STRIKETHROUGH",
-        primary: 9,
-        secondary: None,
+        escape: escape!("9"),
     },
 ];
 
 struct EffectsDisplay(Effects);
 
 impl core::fmt::Display for EffectsDisplay {
+    #[inline]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        if self.0.is_plain() {
-            return Ok(());
+        for index in self.0.index_iter() {
+            METADATA[index].escape.fmt(f)?;
         }
-
-        write!(f, "\x1B[")?;
-        for (i, index) in self.0.index_iter().enumerate() {
-            if i != 0 {
-                write!(f, ";")?;
-            }
-            write!(f, "{}", METADATA[index].primary)?;
-            if let Some(secondary) = METADATA[index].secondary {
-                write!(f, ":{}", secondary)?;
-            }
-        }
-        write!(f, "m")?;
         Ok(())
     }
 }

--- a/crates/anstyle/src/effect.rs
+++ b/crates/anstyle/src/effect.rs
@@ -159,6 +159,15 @@ impl Effects {
     pub fn render(self) -> impl core::fmt::Display {
         EffectsDisplay(self)
     }
+
+    #[inline]
+    #[cfg(feature = "std")]
+    pub(crate) fn write_to(self, write: &mut dyn std::io::Write) -> std::io::Result<()> {
+        for index in self.index_iter() {
+            write.write_all(METADATA[index].escape.as_bytes())?;
+        }
+        Ok(())
+    }
 }
 
 /// # Examples

--- a/crates/anstyle/src/lib.rs
+++ b/crates/anstyle/src/lib.rs
@@ -45,6 +45,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[macro_use]
+mod macros;
+
 mod color;
 mod effect;
 mod reset;

--- a/crates/anstyle/src/macros.rs
+++ b/crates/anstyle/src/macros.rs
@@ -1,0 +1,5 @@
+macro_rules! escape {
+    ($($inner:expr),*) => {
+        concat!("\x1B[", $($inner),*, "m")
+    };
+}

--- a/crates/anstyle/src/reset.rs
+++ b/crates/anstyle/src/reset.rs
@@ -14,6 +14,8 @@ struct ResetDisplay;
 
 impl core::fmt::Display for ResetDisplay {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "\x1B[0m")
+        RESET.fmt(f)
     }
 }
+
+pub(crate) const RESET: &str = "\x1B[0m";

--- a/crates/anstyle/src/style.rs
+++ b/crates/anstyle/src/style.rs
@@ -410,49 +410,21 @@ struct StyleDisplay(Style);
 
 impl core::fmt::Display for StyleDisplay {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        if self.0.is_plain() {
-            return Ok(());
-        }
-
-        write!(f, "\x1B[")?;
-
-        let mut first = true;
-
-        for index in self.0.effects.index_iter() {
-            separator(f, &mut first)?;
-            write!(f, "{}", crate::effect::METADATA[index].primary)?;
-            if let Some(secondary) = crate::effect::METADATA[index].secondary {
-                write!(f, ":{}", secondary)?;
-            }
-        }
+        self.0.effects.render().fmt(f)?;
 
         if let Some(fg) = self.0.fg {
-            separator(f, &mut first)?;
-            fg.ansi_fmt(f, crate::ColorContext::Foreground)?;
+            fg.render_fg().fmt(f)?;
         }
 
         if let Some(bg) = self.0.bg {
-            separator(f, &mut first)?;
-            bg.ansi_fmt(f, crate::ColorContext::Background)?;
+            bg.render_bg().fmt(f)?;
         }
 
         if let Some(underline) = self.0.underline {
-            separator(f, &mut first)?;
-            underline.ansi_fmt(f, crate::ColorContext::Underline)?;
+            underline.render_underline().fmt(f)?;
         }
 
-        write!(f, "m")?;
         Ok(())
-    }
-}
-
-#[inline]
-fn separator(f: &mut core::fmt::Formatter<'_>, first: &mut bool) -> core::fmt::Result {
-    if *first {
-        *first = false;
-        Ok(())
-    } else {
-        write!(f, ";")
     }
 }
 


### PR DESCRIPTION
These ended up having minimal benefit (`StripStream::write` and `Style::write_to` having the most) but I also feel these help make the code more straightforward.