### PR TITLE
Fix crossterm link text

### DIFF
--- a/crates/anstyle-crossterm/README.md
+++ b/crates/anstyle-crossterm/README.md
@@ -1,6 +1,6 @@
 # anstyle-crossterm
 
-> Convert from color styling types to [`ansi_term`](https://lib.rs/crossterm) color types
+> Convert from color styling types to [`crossterm`](https://lib.rs/crossterm) color types
 
 [![Documentation](https://img.shields.io/badge/docs-master-blue.svg)][Documentation]
 ![License](https://img.shields.io/crates/l/anstyle-crossterm.svg)


### PR DESCRIPTION
I guess it was copy-pasted and forgot to change.