### PR TITLE
fix(anstyle)!: Don't assume a color is FG

### DIFF
--- a/crates/anstyle-git/src/lib.rs
+++ b/crates/anstyle-git/src/lib.rs
@@ -8,7 +8,7 @@
 //! assert_eq!(style, anstyle::AnsiColor::Red.on(anstyle::AnsiColor::Blue) | anstyle::Effects::BOLD);
 //!
 //! let hyperlink_style = anstyle_git::parse("#0000ee ul").unwrap();
-//! assert_eq!(hyperlink_style, anstyle::RgbColor(0x00, 0x00, 0xee) | anstyle::Effects::UNDERLINE);
+//! assert_eq!(hyperlink_style, anstyle::RgbColor(0x00, 0x00, 0xee).on_default() | anstyle::Effects::UNDERLINE);
 //! ```
 
 mod sealed {
@@ -195,7 +195,7 @@ mod tests {
         test!("normal" => Style::new());
         test!("normal normal" => Style::new());
         test!("-1 normal" => Style::new());
-        test!("red" => Red);
+        test!("red" => Red.on_default());
         test!("red blue" => Red.on(Blue));
         test!("   red blue   " => Red.on(Blue));
         test!("red\tblue" => Red.on(Blue));
@@ -205,14 +205,14 @@ mod tests {
         test!("yellow green" => Yellow.on(Green));
         test!("white magenta" => White.on(Magenta));
         test!("black cyan" => Black.on(Cyan));
-        test!("red normal" => Red);
+        test!("red normal" => Red.on_default());
         test!("normal red" => Style::new().bg_color(Some(Red.into())));
-        test!("0" => Ansi256Color(0));
+        test!("0" => Ansi256Color(0).on_default());
         test!("8 3" => Ansi256Color(8).on(Ansi256Color(3)));
-        test!("255" => Ansi256Color(255));
-        test!("255 -1" => Ansi256Color(255));
-        test!("#000000" => RgbColor(0,0,0));
-        test!("#204060" => RgbColor(0x20,0x40,0x60));
+        test!("255" => Ansi256Color(255).on_default());
+        test!("255 -1" => Ansi256Color(255).on_default());
+        test!("#000000" => RgbColor(0,0,0).on_default());
+        test!("#204060" => RgbColor(0x20,0x40,0x60).on_default());
 
         test!("bold cyan white" => Cyan.on(White).bold());
         test!("bold cyan nobold white" => Cyan.on(White));

--- a/crates/anstyle-ls/src/lib.rs
+++ b/crates/anstyle-ls/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! ```rust
 //! let style = anstyle_ls::parse("34;03").unwrap();
-//! assert_eq!(style, anstyle::AnsiColor::Blue | anstyle::Effects::ITALIC);
+//! assert_eq!(style, anstyle::AnsiColor::Blue.on_default() | anstyle::Effects::ITALIC);
 //! ```
 
 mod sealed {
@@ -188,12 +188,12 @@ mod tests {
 
     #[test]
     fn parse_simple() {
-        assert_style("31", anstyle::AnsiColor::Red);
+        assert_style("31", anstyle::AnsiColor::Red.on_default());
         assert_style(
             "47",
             anstyle::Style::new().bg_color(Some(anstyle::AnsiColor::White.into())),
         );
-        assert_style("91", anstyle::AnsiColor::BrightRed);
+        assert_style("91", anstyle::AnsiColor::BrightRed.on_default());
         assert_style(
             "107",
             anstyle::Style::new().bg_color(Some(anstyle::AnsiColor::BrightWhite.into())),
@@ -213,42 +213,60 @@ mod tests {
 
     #[test]
     fn parse_font_style() {
-        assert_style("00;31", anstyle::AnsiColor::Red);
-        assert_style("03;34", anstyle::AnsiColor::Blue | anstyle::Effects::ITALIC);
-        assert_style("06;34", anstyle::AnsiColor::Blue | anstyle::Effects::BLINK);
-        assert_style("01;36", anstyle::AnsiColor::Cyan | anstyle::Effects::BOLD);
+        assert_style("00;31", anstyle::AnsiColor::Red.on_default());
+        assert_style(
+            "03;34",
+            anstyle::AnsiColor::Blue.on_default() | anstyle::Effects::ITALIC,
+        );
+        assert_style(
+            "06;34",
+            anstyle::AnsiColor::Blue.on_default() | anstyle::Effects::BLINK,
+        );
+        assert_style(
+            "01;36",
+            anstyle::AnsiColor::Cyan.on_default() | anstyle::Effects::BOLD,
+        );
         assert_style("01;03", anstyle::Effects::BOLD | anstyle::Effects::ITALIC);
     }
 
     #[test]
     fn ignore_unsupported_styles() {
-        assert_style("14;31", anstyle::AnsiColor::Red);
+        assert_style("14;31", anstyle::AnsiColor::Red.on_default());
     }
 
     #[test]
     fn support_reset_of_styles() {
-        assert_style("01;31", anstyle::AnsiColor::Red | anstyle::Effects::BOLD);
-        assert_style("01;31;22", anstyle::AnsiColor::Red);
+        assert_style(
+            "01;31",
+            anstyle::AnsiColor::Red.on_default() | anstyle::Effects::BOLD,
+        );
+        assert_style("01;31;22", anstyle::AnsiColor::Red.on_default());
     }
 
     #[test]
     fn parse_font_style_backwards() {
-        assert_style("34;03", anstyle::AnsiColor::Blue | anstyle::Effects::ITALIC);
-        assert_style("36;01", anstyle::AnsiColor::Cyan | anstyle::Effects::BOLD);
+        assert_style(
+            "34;03",
+            anstyle::AnsiColor::Blue.on_default() | anstyle::Effects::ITALIC,
+        );
+        assert_style(
+            "36;01",
+            anstyle::AnsiColor::Cyan.on_default() | anstyle::Effects::BOLD,
+        );
         assert_style("31;00", anstyle::Style::new());
     }
 
     #[test]
     fn parse_8_bit_colors() {
-        assert_style("38;5;115", anstyle::Ansi256Color(115));
-        assert_style("00;38;5;115", anstyle::Ansi256Color(115));
+        assert_style("38;5;115", anstyle::Ansi256Color(115).on_default());
+        assert_style("00;38;5;115", anstyle::Ansi256Color(115).on_default());
         assert_style(
             "01;38;5;119",
-            anstyle::Ansi256Color(119) | anstyle::Effects::BOLD,
+            anstyle::Ansi256Color(119).on_default() | anstyle::Effects::BOLD,
         );
         assert_style(
             "38;5;119;01",
-            anstyle::Ansi256Color(119) | anstyle::Effects::BOLD,
+            anstyle::Ansi256Color(119).on_default() | anstyle::Effects::BOLD,
         );
         assert_style(
             "58;5;115",
@@ -267,10 +285,13 @@ mod tests {
 
     #[test]
     fn parse_24_bit_colors() {
-        assert_style("38;2;115;3;100", anstyle::RgbColor(115, 3, 100));
+        assert_style(
+            "38;2;115;3;100",
+            anstyle::RgbColor(115, 3, 100).on_default(),
+        );
         assert_style(
             "38;2;115;3;100;3",
-            anstyle::RgbColor(115, 3, 100) | anstyle::Effects::ITALIC,
+            anstyle::RgbColor(115, 3, 100).on_default() | anstyle::Effects::ITALIC,
         );
         assert_style(
             "48;2;100;200;0;1;38;2;0;10;20",

--- a/crates/anstyle/src/color.rs
+++ b/crates/anstyle/src/color.rs
@@ -119,23 +119,6 @@ impl From<(u8, u8, u8)> for Color {
     }
 }
 
-/// Define style with specified foreground color and effects
-///
-/// # Examples
-///
-/// ```rust
-/// let fg = anstyle::Color::from((0, 0, 0));
-/// let style = fg | anstyle::Effects::BOLD | anstyle::Effects::UNDERLINE;
-/// ```
-impl core::ops::BitOr<crate::Effects> for Color {
-    type Output = crate::Style;
-
-    #[inline(always)]
-    fn bitor(self, rhs: crate::Effects) -> Self::Output {
-        crate::Style::new().fg_color(Some(self)) | rhs
-    }
-}
-
 /// Available 4-bit ANSI color palette codes
 ///
 /// The user's terminal defines the meaning of the each palette code.
@@ -337,23 +320,6 @@ impl AnsiColor {
     }
 }
 
-/// Define style with specified foreground color and effects
-///
-/// # Examples
-///
-/// ```rust
-/// let fg = anstyle::AnsiColor::Black;
-/// let style = fg | anstyle::Effects::BOLD | anstyle::Effects::UNDERLINE;
-/// ```
-impl core::ops::BitOr<crate::Effects> for AnsiColor {
-    type Output = crate::Style;
-
-    #[inline(always)]
-    fn bitor(self, rhs: crate::Effects) -> Self::Output {
-        crate::Style::new().fg_color(Some(self.into())) | rhs
-    }
-}
-
 /// 256 (8-bit) color support
 ///
 /// - `0..16` are [`AnsiColor`] palette codes
@@ -479,23 +445,6 @@ impl From<AnsiColor> for Ansi256Color {
     }
 }
 
-/// Define style with specified foreground color and effects
-///
-/// # Examples
-///
-/// ```rust
-/// let fg = anstyle::Ansi256Color(0);
-/// let style = fg | anstyle::Effects::BOLD | anstyle::Effects::UNDERLINE;
-/// ```
-impl core::ops::BitOr<crate::Effects> for Ansi256Color {
-    type Output = crate::Style;
-
-    #[inline(always)]
-    fn bitor(self, rhs: crate::Effects) -> Self::Output {
-        crate::Style::new().fg_color(Some(self.into())) | rhs
-    }
-}
-
 /// 24-bit ANSI RGB color codes
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RgbColor(pub u8, pub u8, pub u8);
@@ -584,23 +533,6 @@ impl From<(u8, u8, u8)> for RgbColor {
     fn from(inner: (u8, u8, u8)) -> Self {
         let (r, g, b) = inner;
         Self(r, g, b)
-    }
-}
-
-/// Define style with specified foreground color and effects
-///
-/// # Examples
-///
-/// ```rust
-/// let fg = anstyle::RgbColor(0, 0, 0);
-/// let style = fg | anstyle::Effects::BOLD | anstyle::Effects::UNDERLINE;
-/// ```
-impl core::ops::BitOr<crate::Effects> for RgbColor {
-    type Output = crate::Style;
-
-    #[inline(always)]
-    fn bitor(self, rhs: crate::Effects) -> Self::Output {
-        crate::Style::new().fg_color(Some(self.into())) | rhs
     }
 }
 

--- a/crates/anstyle/src/style.rs
+++ b/crates/anstyle/src/style.rs
@@ -290,62 +290,6 @@ impl Style {
     }
 }
 
-/// Define style with specified foreground color
-///
-/// # Examples
-///
-/// ```rust
-/// let style: anstyle::Style = anstyle::Color::from((0, 0, 0)).into();
-/// ```
-impl From<crate::Color> for Style {
-    #[inline]
-    fn from(color: crate::Color) -> Self {
-        Self::new().fg_color(Some(color))
-    }
-}
-
-/// Define style with specified foreground color
-///
-/// # Examples
-///
-/// ```rust
-/// let style: anstyle::Style = anstyle::AnsiColor::Black.into();
-/// ```
-impl From<crate::AnsiColor> for Style {
-    #[inline]
-    fn from(color: crate::AnsiColor) -> Self {
-        Self::new().fg_color(Some(color.into()))
-    }
-}
-
-/// Define style with specified foreground color
-///
-/// # Examples
-///
-/// ```rust
-/// let style: anstyle::Style = anstyle::Ansi256Color(0).into();
-/// ```
-impl From<crate::Ansi256Color> for Style {
-    #[inline]
-    fn from(color: crate::Ansi256Color) -> Self {
-        Self::new().fg_color(Some(color.into()))
-    }
-}
-
-/// Define style with specified foreground color
-///
-/// # Examples
-///
-/// ```rust
-/// let style: anstyle::Style = anstyle::RgbColor(0, 0, 0).into();
-/// ```
-impl From<crate::RgbColor> for Style {
-    #[inline]
-    fn from(color: crate::RgbColor) -> Self {
-        Self::new().fg_color(Some(color.into()))
-    }
-}
-
 /// # Examples
 ///
 /// ```rust
@@ -417,26 +361,10 @@ impl core::ops::SubAssign<crate::Effects> for Style {
 /// # Examples
 ///
 /// ```rust
-/// let color = anstyle::RgbColor(0, 0, 0);
-/// assert_eq!(anstyle::Style::new().fg_color(Some(color.into())), color);
-/// assert_ne!(color | anstyle::Effects::BOLD, color);
-/// ```
-impl<C: Into<crate::Color> + Clone> core::cmp::PartialEq<C> for Style {
-    #[inline]
-    fn eq(&self, other: &C) -> bool {
-        let other = other.clone().into();
-        let other = Self::from(other);
-        *self == other
-    }
-}
-
-/// # Examples
-///
-/// ```rust
 /// let effects = anstyle::Effects::BOLD;
 /// assert_eq!(anstyle::Style::new().effects(effects), effects);
 /// assert_ne!(anstyle::Effects::UNDERLINE | effects, effects);
-/// assert_ne!(anstyle::RgbColor(0, 0, 0) | effects, effects);
+/// assert_ne!(anstyle::RgbColor(0, 0, 0).on_default() | effects, effects);
 /// ```
 impl core::cmp::PartialEq<crate::Effects> for Style {
     #[inline]


### PR DESCRIPTION
We might re-add this later but trying to be conservative for 1.0.  We're trying to avoid being clever.