### PR TITLE
chore(ci): Use Cargo package metadata for the MSRV build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,15 +49,20 @@ jobs:
     - name: No-default features
       run: cargo test --workspace --no-default-features
   msrv:
-    name: "Check MSRV: 1.64.0"
+    name: "Check MSRV"
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-    - name: Install Rust
+    - name: Get MSRV from package metadata
+      id: metadata
+      run: |
+        cargo metadata --no-deps --format-version 1 |
+            jq -r '"msrv=" + (.packages[] | select(.name == "anstyle")).rust_version' >> $GITHUB_OUTPUT
+    - name: Install Rust (${{ steps.metadata.outputs.msrv }})
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: 1.64.0  # MSRV
+        toolchain: ${{ steps.metadata.outputs.msrv }}
     - uses: Swatinem/rust-cache@v2
     - name: Default features
       run: cargo check --workspace --all-targets
@@ -106,10 +111,15 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-    - name: Install Rust
+    - name: Get MSRV from package metadata
+      id: metadata
+      run: |
+        cargo metadata --no-deps --format-version 1 |
+            jq -r '"msrv=" + (.packages[] | select(.name == "anstyle")).rust_version' >> $GITHUB_OUTPUT
+    - name: Install Rust (${{ steps.metadata.outputs.msrv }})
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: 1.64.0  # MSRV
+        toolchain: ${{ steps.metadata.outputs.msrv }}
         components: clippy
     - uses: Swatinem/rust-cache@v2
     - name: Install SARIF tools


### PR DESCRIPTION
The MSRV for the build jobs is now retrieved from the Cargo package metadata via `cargo metadata` & `jq`.
This will reduce the changes needed for future version bumps.