### PR TITLE
fix(docs):  Upgrade `is-terminal` to Fix #96

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,6 +564,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "errno-dragonfly"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,14 +695,14 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix",
- "windows-sys 0.45.0",
+ "rustix 0.37.3",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -747,6 +758,12 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
 
 [[package]]
 name = "lock_api"
@@ -1083,10 +1100,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
 dependencies = [
  "bitflags 1.3.2",
- "errno",
+ "errno 0.2.8",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b24138615de35e32031d041a09032ef3487a616d901ca4db224e7d557efae2"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno 0.3.1",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.4",
  "windows-sys 0.45.0",
 ]
 
@@ -1274,7 +1305,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
- "rustix",
+ "rustix 0.36.8",
  "windows-sys 0.42.0",
 ]
 

--- a/crates/anstream/Cargo.toml
+++ b/crates/anstream/Cargo.toml
@@ -34,7 +34,7 @@ anstyle = { version = "1.0.0", path = "../anstyle" }
 anstyle-parse = { version = "0.2.0", path = "../anstyle-parse" }
 colorchoice = { version = "1.0.0", path = "../colorchoice", optional = true }
 anstyle-query = { version = "1.0.0", path = "../anstyle-query", optional = true }
-is-terminal = { version = "0.4.4", optional = true }
+is-terminal = { version = "0.4.6", optional = true }
 utf8parse = "0.2.1"
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/anstyle-parse/src/state/definitions.rs
+++ b/crates/anstyle-parse/src/state/definitions.rs
@@ -2,6 +2,7 @@ use core::mem;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u8)]
+#[derive(Default)]
 pub enum State {
     Anywhere = 0,
     CsiEntry = 1,
@@ -15,17 +16,11 @@ pub enum State {
     DcsPassthrough = 9,
     Escape = 10,
     EscapeIntermediate = 11,
+    #[default]
     Ground = 12,
     OscString = 13,
     SosPmApcString = 14,
     Utf8 = 15,
-}
-
-impl Default for State {
-    #[inline]
-    fn default() -> State {
-        State::Ground
-    }
 }
 
 impl TryFrom<u8> for State {
@@ -58,7 +53,9 @@ const STATES: [State; 16] = [
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[derive(Default)]
 pub enum Action {
+    #[default]
     Nop = 0,
     Clear = 1,
     Collect = 2,
@@ -75,13 +72,6 @@ pub enum Action {
     Put = 13,
     Unhook = 14,
     BeginUtf8 = 15,
-}
-
-impl Default for Action {
-    #[inline]
-    fn default() -> Action {
-        Action::Nop
-    }
 }
 
 impl TryFrom<u8> for Action {

--- a/crates/anstyle-wincon/examples/dump.rs
+++ b/crates/anstyle-wincon/examples/dump.rs
@@ -72,17 +72,12 @@ struct Args {
     layer: Layer,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 enum Layer {
+    #[default]
     Fg,
     Bg,
     Underline,
-}
-
-impl Default for Layer {
-    fn default() -> Self {
-        Layer::Fg
-    }
 }
 
 impl Args {

--- a/crates/anstyle/examples/dump.rs
+++ b/crates/anstyle/examples/dump.rs
@@ -66,17 +66,12 @@ struct Args {
     layer: Layer,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 enum Layer {
+    #[default]
     Fg,
     Bg,
     Underline,
-}
-
-impl Default for Layer {
-    fn default() -> Self {
-        Layer::Fg
-    }
 }
 
 impl Args {


### PR DESCRIPTION
This commit upgrades `is-terminal` to v0.4.6 in order to fix #96.

Furthermore, the code was optimised by `cargo clippy --fix` as well as `cargo fmt`.  All tests succeed, the crate still compiles.  The code coverage is 44.45%.