### PR TITLE
gate the max_display_buffer on the std feature

### DIFF
--- a/crates/anstyle/src/color.rs
+++ b/crates/anstyle/src/color.rs
@@ -598,6 +598,7 @@ impl core::fmt::Display for DisplayBuffer {
 }
 
 #[cfg(test)]
+#[cfg(feature = "std")]
 mod test {
     use super::*;
 


### PR DESCRIPTION
Without this patch:

```
$ cargo test --no-default-features
   Compiling anstyle v1.0.1 (/home/capitol/project/anstyle/crates/anstyle)
error[E0599]: no method named `to_string` found for opaque type `impl Display` in the current scope
   --> crates/anstyle/src/color.rs:607:36
    |
607 |         let actual = c.render_fg().to_string();
    |                                    ^^^^^^^^^ method not found in `impl Display`
   --> /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/alloc/src/string.rs:2503:8
    |
    = note: the method is available for `impl Display` here
    |
    = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
602 +     use alloc::string::ToString;
    |

For more information about this error, try `rustc --explain E0599`.
error: could not compile `anstyle` (lib test) due to previous error
warning: build failed, waiting for other jobs to finish...
```