### PR TITLE
fix(anstream)!: Simplify locking code

### DIFF
--- a/crates/anstream/src/lockable.rs
+++ b/crates/anstream/src/lockable.rs
@@ -36,7 +36,7 @@ impl Lockable for anstyle_wincon::Console<std::io::Stdout> {
 
     #[inline]
     fn lock(self) -> Self::Locked {
-        self.map(|s| s.lock())
+        self.lock()
     }
 }
 
@@ -46,6 +46,6 @@ impl Lockable for anstyle_wincon::Console<std::io::Stderr> {
 
     #[inline]
     fn lock(self) -> Self::Locked {
-        self.map(|s| s.lock())
+        self.lock()
     }
 }

--- a/crates/anstream/src/lockable.rs
+++ b/crates/anstream/src/lockable.rs
@@ -32,7 +32,7 @@ impl Lockable for std::io::Stderr {
 
 #[cfg(all(windows, feature = "wincon"))]
 impl Lockable for anstyle_wincon::Console<std::io::Stdout> {
-    type Locked = anstyle_wincon::Console<<std::io::Stdout as Lockable>::Locked>;
+    type Locked = anstyle_wincon::Console<std::io::StdoutLock<'static>>;
 
     #[inline]
     fn lock(self) -> Self::Locked {
@@ -42,7 +42,7 @@ impl Lockable for anstyle_wincon::Console<std::io::Stdout> {
 
 #[cfg(all(windows, feature = "wincon"))]
 impl Lockable for anstyle_wincon::Console<std::io::Stderr> {
-    type Locked = anstyle_wincon::Console<<std::io::Stderr as Lockable>::Locked>;
+    type Locked = anstyle_wincon::Console<std::io::StderrLock<'static>>;
 
     #[inline]
     fn lock(self) -> Self::Locked {

--- a/crates/anstream/src/lockable.rs
+++ b/crates/anstream/src/lockable.rs
@@ -1,6 +1,3 @@
-#[cfg(all(windows, feature = "wincon"))]
-use crate::RawStream;
-
 /// Explicitly lock a [`std::io::Write`]able
 pub trait Lockable {
     type Locked;

--- a/crates/anstream/src/lockable.rs
+++ b/crates/anstream/src/lockable.rs
@@ -34,12 +34,18 @@ impl Lockable for std::io::Stderr {
 }
 
 #[cfg(all(windows, feature = "wincon"))]
-impl<S> Lockable for anstyle_wincon::Console<S>
-where
-    S: RawStream + Lockable,
-    <S as Lockable>::Locked: RawStream,
-{
-    type Locked = anstyle_wincon::Console<<S as Lockable>::Locked>;
+impl Lockable for anstyle_wincon::Console<std::io::Stdout> {
+    type Locked = anstyle_wincon::Console<<std::io::Stdout as Lockable>::Locked>;
+
+    #[inline]
+    fn lock(self) -> Self::Locked {
+        self.map(|s| s.lock())
+    }
+}
+
+#[cfg(all(windows, feature = "wincon"))]
+impl Lockable for anstyle_wincon::Console<std::io::Stderr> {
+    type Locked = anstyle_wincon::Console<<std::io::Stderr as Lockable>::Locked>;
 
     #[inline]
     fn lock(self) -> Self::Locked {

--- a/crates/anstream/src/wincon.rs
+++ b/crates/anstream/src/wincon.rs
@@ -79,7 +79,7 @@ where
 }
 
 impl Lockable for WinconStream<std::io::Stdout> {
-    type Locked = WinconStream<<std::io::Stdout as Lockable>::Locked>;
+    type Locked = WinconStream<std::io::StdoutLock<'static>>;
 
     #[inline]
     fn lock(self) -> Self::Locked {
@@ -91,7 +91,7 @@ impl Lockable for WinconStream<std::io::Stdout> {
 }
 
 impl Lockable for WinconStream<std::io::Stderr> {
-    type Locked = WinconStream<<std::io::Stderr as Lockable>::Locked>;
+    type Locked = WinconStream<std::io::StderrLock<'static>>;
 
     #[inline]
     fn lock(self) -> Self::Locked {

--- a/crates/anstream/src/wincon.rs
+++ b/crates/anstream/src/wincon.rs
@@ -78,12 +78,20 @@ where
     }
 }
 
-impl<S> Lockable for WinconStream<S>
-where
-    S: RawStream + Lockable,
-    <S as Lockable>::Locked: RawStream,
-{
-    type Locked = WinconStream<<S as Lockable>::Locked>;
+impl Lockable for WinconStream<std::io::Stdout> {
+    type Locked = WinconStream<<std::io::Stdout as Lockable>::Locked>;
+
+    #[inline]
+    fn lock(self) -> Self::Locked {
+        Self::Locked {
+            console: self.console.lock(),
+            state: self.state,
+        }
+    }
+}
+
+impl Lockable for WinconStream<std::io::Stderr> {
+    type Locked = WinconStream<<std::io::Stderr as Lockable>::Locked>;
 
     #[inline]
     fn lock(self) -> Self::Locked {

--- a/crates/anstyle-wincon/src/console.rs
+++ b/crates/anstyle-wincon/src/console.rs
@@ -59,20 +59,6 @@ where
         self.reset()
     }
 
-    /// Allow changing the stream
-    pub fn map<S1: crate::WinconStream + std::io::Write>(
-        mut self,
-        op: impl FnOnce(S) -> S1,
-    ) -> Console<S1> {
-        Console {
-            stream: Some(op(self.stream.take().unwrap())),
-            initial_fg: self.initial_fg,
-            initial_bg: self.initial_bg,
-            last_fg: self.last_fg,
-            last_bg: self.last_bg,
-        }
-    }
-
     /// Get the inner writer
     #[inline]
     pub fn into_inner(mut self) -> S {


### PR DESCRIPTION
Being generic has offered little benefit (maybe less boilerplate) but
has caused a lot of pain whenever I'm trying to make changes.