### PR TITLE
feat(stream): Query the current choice

### DIFF
--- a/crates/anstream/src/auto.rs
+++ b/crates/anstream/src/auto.rs
@@ -131,6 +131,19 @@ where
             StreamInner::Wincon(_) => true, // its only ever a terminal
         }
     }
+
+    /// Prefer [`AutoStream::choice`]
+    ///
+    /// This doesn't report what is requested but what is currently active.
+    #[inline]
+    pub fn current_choice(&self) -> ColorChoice {
+        match &self.inner {
+            StreamInner::PassThrough(_) => ColorChoice::AlwaysAnsi,
+            StreamInner::Strip(_) => ColorChoice::Never,
+            #[cfg(all(windows, feature = "wincon"))]
+            StreamInner::Wincon(_) => ColorChoice::Always,
+        }
+    }
 }
 
 #[cfg(feature = "auto")]


### PR DESCRIPTION
Have a situation in cargo where we use `AutoStream::new` and then need to later check the color choice.  Rather than requiring the caller to check both values and `and` them together, let's just report it.

Ideally, we could remove those color choice checks but that will take a bit of plumbing work.