### PR TITLE
feat(stream): Allow writing to a Box<Write>

### DIFF
--- a/crates/anstream/src/stream.rs
+++ b/crates/anstream/src/stream.rs
@@ -23,6 +23,10 @@ impl RawStream for std::io::StderrLock<'_> {}
 
 impl RawStream for &'_ mut std::io::StderrLock<'_> {}
 
+impl RawStream for Box<dyn std::io::Write> {}
+
+impl RawStream for &'_ mut Box<dyn std::io::Write> {}
+
 impl RawStream for std::fs::File {}
 
 impl RawStream for &'_ mut std::fs::File {}
@@ -74,6 +78,20 @@ impl IsTerminal for &'_ mut std::io::StderrLock<'_> {
     #[inline]
     fn is_terminal(&self) -> bool {
         (**self).is_terminal()
+    }
+}
+
+impl IsTerminal for Box<dyn std::io::Write> {
+    #[inline]
+    fn is_terminal(&self) -> bool {
+        false
+    }
+}
+
+impl IsTerminal for &'_ mut Box<dyn std::io::Write> {
+    #[inline]
+    fn is_terminal(&self) -> bool {
+        false
     }
 }
 
@@ -149,6 +167,15 @@ impl AsLockedWrite for std::io::StderrLock<'static> {
     }
 }
 
+impl AsLockedWrite for Box<dyn std::io::Write> {
+    type Write<'w> = &'w mut Self;
+
+    #[inline]
+    fn as_locked_write(&mut self) -> Self::Write<'_> {
+        self
+    }
+}
+
 impl AsLockedWrite for std::fs::File {
     type Write<'w> = &'w mut Self;
 
@@ -181,6 +208,10 @@ mod private {
     impl Sealed for std::io::StderrLock<'_> {}
 
     impl Sealed for &'_ mut std::io::StderrLock<'_> {}
+
+    impl Sealed for Box<dyn std::io::Write> {}
+
+    impl Sealed for &'_ mut Box<dyn std::io::Write> {}
 
     impl Sealed for std::fs::File {}
 

--- a/crates/anstyle-wincon/src/stream.rs
+++ b/crates/anstyle-wincon/src/stream.rs
@@ -9,6 +9,28 @@ pub trait WinconStream {
     ) -> std::io::Result<usize>;
 }
 
+impl WinconStream for Box<dyn std::io::Write> {
+    fn write_colored(
+        &mut self,
+        fg: Option<anstyle::AnsiColor>,
+        bg: Option<anstyle::AnsiColor>,
+        data: &[u8],
+    ) -> std::io::Result<usize> {
+        crate::ansi::write_colored(self, fg, bg, data)
+    }
+}
+
+impl WinconStream for &'_ mut Box<dyn std::io::Write> {
+    fn write_colored(
+        &mut self,
+        fg: Option<anstyle::AnsiColor>,
+        bg: Option<anstyle::AnsiColor>,
+        data: &[u8],
+    ) -> std::io::Result<usize> {
+        (**self).write_colored(fg, bg, data)
+    }
+}
+
 impl WinconStream for std::fs::File {
     fn write_colored(
         &mut self,


### PR DESCRIPTION
Cargo uses this as an alternative to stdout/stderr for tests and we need to strip the content going to it if we want full flexibility in styling.