### PR TITLE
feat(stream): Allow wrapping a Vec directly

### DIFF
--- a/crates/anstream/benches/stream.rs
+++ b/crates/anstream/benches/stream.rs
@@ -15,7 +15,7 @@ fn stream(c: &mut Criterion) {
         let mut group = c.benchmark_group(name);
         group.bench_function("nop", |b| {
             b.iter(|| {
-                let buffer = anstream::Buffer::with_capacity(content.len());
+                let buffer = Vec::with_capacity(content.len());
                 let mut stream = buffer;
 
                 stream.write_all(content).unwrap();
@@ -25,7 +25,7 @@ fn stream(c: &mut Criterion) {
         });
         group.bench_function("StripStream", |b| {
             b.iter(|| {
-                let buffer = anstream::Buffer::with_capacity(content.len());
+                let buffer = Vec::with_capacity(content.len());
                 let mut stream = anstream::StripStream::new(buffer);
 
                 stream.write_all(content).unwrap();
@@ -36,7 +36,7 @@ fn stream(c: &mut Criterion) {
         #[cfg(all(windows, feature = "wincon"))]
         group.bench_function("WinconStream", |b| {
             b.iter(|| {
-                let buffer = anstream::Buffer::with_capacity(content.len());
+                let buffer = Vec::with_capacity(content.len());
                 let mut stream = anstream::WinconStream::new(buffer);
 
                 stream.write_all(content).unwrap();
@@ -46,7 +46,7 @@ fn stream(c: &mut Criterion) {
         });
         group.bench_function("AutoStream::always_ansi", |b| {
             b.iter(|| {
-                let buffer = anstream::Buffer::with_capacity(content.len());
+                let buffer = Vec::with_capacity(content.len());
                 let mut stream = anstream::AutoStream::always_ansi(buffer);
 
                 stream.write_all(content).unwrap();
@@ -56,7 +56,7 @@ fn stream(c: &mut Criterion) {
         });
         group.bench_function("AutoStream::always", |b| {
             b.iter(|| {
-                let buffer = anstream::Buffer::with_capacity(content.len());
+                let buffer = Vec::with_capacity(content.len());
                 let mut stream = anstream::AutoStream::always(buffer);
 
                 stream.write_all(content).unwrap();
@@ -66,7 +66,7 @@ fn stream(c: &mut Criterion) {
         });
         group.bench_function("AutoStream::never", |b| {
             b.iter(|| {
-                let buffer = anstream::Buffer::with_capacity(content.len());
+                let buffer = Vec::with_capacity(content.len());
                 let mut stream = anstream::AutoStream::never(buffer);
 
                 stream.write_all(content).unwrap();

--- a/crates/anstream/src/buffer.rs
+++ b/crates/anstream/src/buffer.rs
@@ -1,5 +1,9 @@
+#![allow(deprecated)]
+
 /// In-memory [`RawStream`][crate::stream::RawStream]
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
+#[deprecated(since = "0.6.2", note = "Use Vec")]
+#[doc(hidden)]
 pub struct Buffer(Vec<u8>);
 
 impl Buffer {

--- a/crates/anstream/src/lib.rs
+++ b/crates/anstream/src/lib.rs
@@ -51,6 +51,7 @@ pub use strip::StripStream;
 #[cfg(all(windows, feature = "wincon"))]
 pub use wincon::WinconStream;
 
+#[allow(deprecated)]
 pub use buffer::Buffer;
 
 /// Create an ANSI escape code compatible stdout

--- a/crates/anstream/src/macros.rs
+++ b/crates/anstream/src/macros.rs
@@ -65,13 +65,13 @@ macro_rules! print {
 
             let stdio = std::io::stdout();
             let choice = $crate::AutoStream::choice(&stdio);
-            let buffer = $crate::Buffer::new();
+            let buffer = Vec::new();
             let mut stream = $crate::AutoStream::new(buffer, choice);
             // Ignore errors rather than panic
             let _ = ::std::write!(&mut stream, $($arg)*);
             let buffer = stream.into_inner();
             // Should be UTF-8 but not wanting to panic
-            let buffer = String::from_utf8_lossy(buffer.as_bytes());
+            let buffer = String::from_utf8_lossy(&buffer);
             ::std::print!("{}", buffer)
         } else {
             use std::io::Write as _;
@@ -146,13 +146,13 @@ macro_rules! println {
 
             let stdio = std::io::stdout();
             let choice = $crate::AutoStream::choice(&stdio);
-            let buffer = $crate::Buffer::new();
+            let buffer = Vec::new();
             let mut stream = $crate::AutoStream::new(buffer, choice);
             // Ignore errors rather than panic
             let _ = ::std::write!(&mut stream, $($arg)*);
             let buffer = stream.into_inner();
             // Should be UTF-8 but not wanting to panic
-            let buffer = String::from_utf8_lossy(buffer.as_bytes());
+            let buffer = String::from_utf8_lossy(&buffer);
             ::std::println!("{}", buffer)
         } else {
             use std::io::Write as _;
@@ -206,13 +206,13 @@ macro_rules! eprint {
 
             let stdio = std::io::stderr();
             let choice = $crate::AutoStream::choice(&stdio);
-            let buffer = $crate::Buffer::new();
+            let buffer = Vec::new();
             let mut stream = $crate::AutoStream::new(buffer, choice);
             // Ignore errors rather than panic
             let _ = ::std::write!(&mut stream, $($arg)*);
             let buffer = stream.into_inner();
             // Should be UTF-8 but not wanting to panic
-            let buffer = String::from_utf8_lossy(buffer.as_bytes());
+            let buffer = String::from_utf8_lossy(&buffer);
             ::std::eprint!("{}", buffer)
         } else {
             use std::io::Write as _;
@@ -269,13 +269,13 @@ macro_rules! eprintln {
 
             let stdio = std::io::stderr();
             let choice = $crate::AutoStream::choice(&stdio);
-            let buffer = $crate::Buffer::new();
+            let buffer = Vec::new();
             let mut stream = $crate::AutoStream::new(buffer, choice);
             // Ignore errors rather than panic
             let _ = ::std::write!(&mut stream, $($arg)*);
             let buffer = stream.into_inner();
             // Should be UTF-8 but not wanting to panic
-            let buffer = String::from_utf8_lossy(buffer.as_bytes());
+            let buffer = String::from_utf8_lossy(&buffer);
             ::std::eprintln!("{}", buffer)
         } else {
             use std::io::Write as _;
@@ -377,13 +377,13 @@ macro_rules! panic {
 
         let panic_stream = std::io::stderr();
         let choice = $crate::AutoStream::choice(&panic_stream);
-        let buffer = $crate::Buffer::new();
+        let buffer = Vec::new();
         let mut stream = $crate::AutoStream::new(buffer, choice);
         // Ignore errors rather than panic
         let _ = ::std::write!(&mut stream, $($arg)*);
         let buffer = stream.into_inner();
         // Should be UTF-8 but not wanting to panic
-        let buffer = String::from_utf8_lossy(buffer.as_bytes()).into_owned();
+        let buffer = String::from_utf8_lossy(&buffer).into_owned();
         ::std::panic!("{}", buffer)
     }};
 }

--- a/crates/anstream/src/stream.rs
+++ b/crates/anstream/src/stream.rs
@@ -27,6 +27,10 @@ impl RawStream for Box<dyn std::io::Write> {}
 
 impl RawStream for &'_ mut Box<dyn std::io::Write> {}
 
+impl RawStream for Vec<u8> {}
+
+impl RawStream for &'_ mut Vec<u8> {}
+
 impl RawStream for std::fs::File {}
 
 impl RawStream for &'_ mut std::fs::File {}
@@ -89,6 +93,20 @@ impl IsTerminal for Box<dyn std::io::Write> {
 }
 
 impl IsTerminal for &'_ mut Box<dyn std::io::Write> {
+    #[inline]
+    fn is_terminal(&self) -> bool {
+        false
+    }
+}
+
+impl IsTerminal for Vec<u8> {
+    #[inline]
+    fn is_terminal(&self) -> bool {
+        false
+    }
+}
+
+impl IsTerminal for &'_ mut Vec<u8> {
     #[inline]
     fn is_terminal(&self) -> bool {
         false
@@ -176,6 +194,15 @@ impl AsLockedWrite for Box<dyn std::io::Write> {
     }
 }
 
+impl AsLockedWrite for Vec<u8> {
+    type Write<'w> = &'w mut Self;
+
+    #[inline]
+    fn as_locked_write(&mut self) -> Self::Write<'_> {
+        self
+    }
+}
+
 impl AsLockedWrite for std::fs::File {
     type Write<'w> = &'w mut Self;
 
@@ -212,6 +239,10 @@ mod private {
     impl Sealed for Box<dyn std::io::Write> {}
 
     impl Sealed for &'_ mut Box<dyn std::io::Write> {}
+
+    impl Sealed for Vec<u8> {}
+
+    impl Sealed for &'_ mut Vec<u8> {}
 
     impl Sealed for std::fs::File {}
 

--- a/crates/anstream/src/stream.rs
+++ b/crates/anstream/src/stream.rs
@@ -35,8 +35,10 @@ impl RawStream for std::fs::File {}
 
 impl RawStream for &'_ mut std::fs::File {}
 
+#[allow(deprecated)]
 impl RawStream for crate::Buffer {}
 
+#[allow(deprecated)]
 impl RawStream for &'_ mut crate::Buffer {}
 
 pub trait IsTerminal: private::Sealed {
@@ -127,6 +129,7 @@ impl IsTerminal for &'_ mut std::fs::File {
     }
 }
 
+#[allow(deprecated)]
 impl IsTerminal for crate::Buffer {
     #[inline]
     fn is_terminal(&self) -> bool {
@@ -134,6 +137,7 @@ impl IsTerminal for crate::Buffer {
     }
 }
 
+#[allow(deprecated)]
 impl IsTerminal for &'_ mut crate::Buffer {
     #[inline]
     fn is_terminal(&self) -> bool {
@@ -212,6 +216,7 @@ impl AsLockedWrite for std::fs::File {
     }
 }
 
+#[allow(deprecated)]
 impl AsLockedWrite for crate::Buffer {
     type Write<'w> = &'w mut Self;
 
@@ -248,7 +253,9 @@ mod private {
 
     impl Sealed for &'_ mut std::fs::File {}
 
+    #[allow(deprecated)]
     impl Sealed for crate::Buffer {}
 
+    #[allow(deprecated)]
     impl Sealed for &'_ mut crate::Buffer {}
 }

--- a/crates/anstream/src/strip.rs
+++ b/crates/anstream/src/strip.rs
@@ -165,7 +165,7 @@ mod test {
         #[test]
         #[cfg_attr(miri, ignore)]  // See https://github.com/AltSysrq/proptest/issues/253
         fn write_all_no_escapes(s in "\\PC*") {
-            let buffer = crate::Buffer::new();
+            let buffer = Vec::new();
             let mut stream = StripStream::new(buffer);
             stream.write_all(s.as_bytes()).unwrap();
             let buffer = stream.into_inner();
@@ -176,7 +176,7 @@ mod test {
         #[test]
         #[cfg_attr(miri, ignore)]  // See https://github.com/AltSysrq/proptest/issues/253
         fn write_byte_no_escapes(s in "\\PC*") {
-            let buffer = crate::Buffer::new();
+            let buffer = Vec::new();
             let mut stream = StripStream::new(buffer);
             for byte in s.as_bytes() {
                 stream.write_all(&[*byte]).unwrap();
@@ -189,7 +189,7 @@ mod test {
         #[test]
         #[cfg_attr(miri, ignore)]  // See https://github.com/AltSysrq/proptest/issues/253
         fn write_all_random(s in any::<Vec<u8>>()) {
-            let buffer = crate::Buffer::new();
+            let buffer = Vec::new();
             let mut stream = StripStream::new(buffer);
             stream.write_all(s.as_slice()).unwrap();
             let buffer = stream.into_inner();
@@ -203,7 +203,7 @@ mod test {
         #[test]
         #[cfg_attr(miri, ignore)]  // See https://github.com/AltSysrq/proptest/issues/253
         fn write_byte_random(s in any::<Vec<u8>>()) {
-            let buffer = crate::Buffer::new();
+            let buffer = Vec::new();
             let mut stream = StripStream::new(buffer);
             for byte in s.as_slice() {
                 stream.write_all(&[*byte]).unwrap();

--- a/crates/anstream/src/wincon.rs
+++ b/crates/anstream/src/wincon.rs
@@ -168,7 +168,7 @@ mod test {
         #[test]
         #[cfg_attr(miri, ignore)]  // See https://github.com/AltSysrq/proptest/issues/253
         fn write_all_no_escapes(s in "\\PC*") {
-            let buffer = crate::Buffer::new();
+            let buffer = Vec::new();
             let mut stream = WinconStream::new(buffer);
             stream.write_all(s.as_bytes()).unwrap();
             let buffer = stream.into_inner();
@@ -179,7 +179,7 @@ mod test {
         #[test]
         #[cfg_attr(miri, ignore)]  // See https://github.com/AltSysrq/proptest/issues/253
         fn write_byte_no_escapes(s in "\\PC*") {
-            let buffer = crate::Buffer::new();
+            let buffer = Vec::new();
             let mut stream = WinconStream::new(buffer);
             for byte in s.as_bytes() {
                 stream.write_all(&[*byte]).unwrap();
@@ -192,7 +192,7 @@ mod test {
         #[test]
         #[cfg_attr(miri, ignore)]  // See https://github.com/AltSysrq/proptest/issues/253
         fn write_all_random(s in any::<Vec<u8>>()) {
-            let buffer = crate::Buffer::new();
+            let buffer = Vec::new();
             let mut stream = WinconStream::new(buffer);
             stream.write_all(s.as_slice()).unwrap();
         }
@@ -200,7 +200,7 @@ mod test {
         #[test]
         #[cfg_attr(miri, ignore)]  // See https://github.com/AltSysrq/proptest/issues/253
         fn write_byte_random(s in any::<Vec<u8>>()) {
-            let buffer = crate::Buffer::new();
+            let buffer = Vec::new();
             let mut stream = WinconStream::new(buffer);
             for byte in s.as_slice() {
                 stream.write_all(&[*byte]).unwrap();

--- a/crates/anstyle-wincon/src/stream.rs
+++ b/crates/anstyle-wincon/src/stream.rs
@@ -64,6 +64,17 @@ impl WinconStream for Vec<u8> {
     }
 }
 
+impl WinconStream for &'_ mut Vec<u8> {
+    fn write_colored(
+        &mut self,
+        fg: Option<anstyle::AnsiColor>,
+        bg: Option<anstyle::AnsiColor>,
+        data: &[u8],
+    ) -> std::io::Result<usize> {
+        (**self).write_colored(fg, bg, data)
+    }
+}
+
 impl WinconStream for std::io::Stdout {
     fn write_colored(
         &mut self,


### PR DESCRIPTION
We also deprecate `Buffer`.

This is because we no longer have to deal with foreign traits.