### PR TITLE
feat(anstream): Expose AutoStream::new always

### DIFF
--- a/crates/anstream/Cargo.toml
+++ b/crates/anstream/Cargo.toml
@@ -26,7 +26,7 @@ pre-release-replacements = [
 
 [features]
 default = ["auto", "wincon"]
-auto = ["dep:anstyle-query", "dep:colorchoice"]
+auto = ["dep:anstyle-query"]
 wincon = ["dep:anstyle-wincon"]
 # Enable in `dev-dependencies` to make sure output is captured for tests
 test = []
@@ -34,7 +34,7 @@ test = []
 [dependencies]
 anstyle = { version = "1.0.0", path = "../anstyle" }
 anstyle-parse = { version = "0.2.0", path = "../anstyle-parse" }
-colorchoice = { version = "1.0.0", path = "../colorchoice", optional = true }
+colorchoice = { version = "1.0.0", path = "../colorchoice" }
 anstyle-query = { version = "1.0.0", path = "../anstyle-query", optional = true }
 utf8parse = "0.2.1"
 

--- a/crates/anstream/src/auto.rs
+++ b/crates/anstream/src/auto.rs
@@ -25,11 +25,13 @@ where
     S: RawStream,
 {
     /// Runtime control over styling behavior
-    #[cfg(feature = "auto")]
     #[inline]
     pub fn new(raw: S, choice: ColorChoice) -> Self {
         match choice {
+            #[cfg(feature = "auto")]
             ColorChoice::Auto => Self::auto(raw),
+            #[cfg(not(feature = "auto"))]
+            ColorChoice::Auto => Self::never(raw),
             ColorChoice::AlwaysAnsi => Self::always_ansi(raw),
             ColorChoice::Always => Self::always(raw),
             ColorChoice::Never => Self::never(raw),

--- a/crates/anstream/src/lib.rs
+++ b/crates/anstream/src/lib.rs
@@ -78,5 +78,4 @@ pub fn stderr() -> Stderr {
 }
 
 /// Selection for overriding color output
-#[cfg(feature = "auto")]
 pub use colorchoice::ColorChoice;


### PR DESCRIPTION
The `colorchoice` dep is light enough of a dependency that it shouldn't be a problem and this simplifies calling code when `auto` is conditional.