### PR TITLE
RFC: Style code/reset rendering via Display

### DIFF
--- a/crates/anstyle/src/reset.rs
+++ b/crates/anstyle/src/reset.rs
@@ -4,16 +4,15 @@ pub struct Reset;
 
 impl Reset {
     /// Render the ANSI code
+    ///
+    /// `Reset` also implements `Display` directly, so calling this method is optional.
     #[inline]
     pub fn render(self) -> impl core::fmt::Display + Copy + Clone {
-        ResetDisplay
+        self
     }
 }
 
-#[derive(Copy, Clone, Default, Debug)]
-struct ResetDisplay;
-
-impl core::fmt::Display for ResetDisplay {
+impl core::fmt::Display for Reset {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         RESET.fmt(f)
     }
@@ -25,5 +24,4 @@ pub(crate) const RESET: &str = "\x1B[0m";
 fn print_size_of() {
     use std::mem::size_of;
     dbg!(size_of::<Reset>());
-    dbg!(size_of::<ResetDisplay>());
 }

--- a/crates/anstyle/src/style.rs
+++ b/crates/anstyle/src/style.rs
@@ -91,6 +91,8 @@ impl Style {
     }
 
     /// Render the ANSI code
+    ///
+    /// `Style` also implements `Display` directly, so calling this method is optional.
     #[inline]
     pub fn render(self) -> impl core::fmt::Display + Copy + Clone {
         StyleDisplay(self)
@@ -391,6 +393,12 @@ impl core::cmp::PartialEq<crate::Effects> for Style {
     fn eq(&self, other: &crate::Effects) -> bool {
         let other = Self::from(*other);
         *self == other
+    }
+}
+
+impl core::fmt::Display for Style {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.fmt_to(f)
     }
 }
 

--- a/crates/anstyle/src/style.rs
+++ b/crates/anstyle/src/style.rs
@@ -2,10 +2,17 @@ use crate::reset::RESET;
 
 /// ANSI Text styling
 ///
+/// You can print a `Style` to render the corresponding ANSI code.
+/// Using the alternate flag `#` will render the ANSI reset code, if needed.
+/// Together, this makes it convenient to render styles using inline format arguments.
+///
 /// # Examples
 ///
 /// ```rust
 /// let style = anstyle::Style::new().bold();
+///
+/// let value = 42;
+/// println!("{style}{value}{style:#}");
 /// ```
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Style {

--- a/crates/anstyle/src/style.rs
+++ b/crates/anstyle/src/style.rs
@@ -96,6 +96,26 @@ impl Style {
         StyleDisplay(self)
     }
 
+    fn fmt_to(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        use core::fmt::Display as _;
+
+        self.effects.render().fmt(f)?;
+
+        if let Some(fg) = self.fg {
+            fg.render_fg().fmt(f)?;
+        }
+
+        if let Some(bg) = self.bg {
+            bg.render_bg().fmt(f)?;
+        }
+
+        if let Some(underline) = self.underline {
+            underline.render_underline().fmt(f)?;
+        }
+
+        Ok(())
+    }
+
     /// Write the ANSI code
     #[inline]
     #[cfg(feature = "std")]
@@ -379,21 +399,7 @@ struct StyleDisplay(Style);
 
 impl core::fmt::Display for StyleDisplay {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        self.0.effects.render().fmt(f)?;
-
-        if let Some(fg) = self.0.fg {
-            fg.render_fg().fmt(f)?;
-        }
-
-        if let Some(bg) = self.0.bg {
-            bg.render_bg().fmt(f)?;
-        }
-
-        if let Some(underline) = self.0.underline {
-            underline.render_underline().fmt(f)?;
-        }
-
-        Ok(())
+        self.0.fmt_to(f)
     }
 }
 

--- a/crates/anstyle/src/style.rs
+++ b/crates/anstyle/src/style.rs
@@ -397,8 +397,13 @@ impl core::cmp::PartialEq<crate::Effects> for Style {
 }
 
 impl core::fmt::Display for Style {
+    #[inline]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        self.fmt_to(f)
+        if f.alternate() {
+            self.render_reset().fmt(f)
+        } else {
+            self.fmt_to(f)
+        }
     }
 }
 


### PR DESCRIPTION
This is an unusual suggestion, but I've tried it out in practice and it feels
really comfortable to use. I wanted to run it by you to see if it seemed
reasonable.

I found the requirement to call `.render()` and `.render_reset()` rather
verbose, particularly when trying to render several color styles in one line. I
started thinking about ways to make that more convenient, and this idea
occurred to me.

With this PR applied, `Style` and `Reset` implement `Display` directly,
rendering the ANSI code, without having to call `.render()`. That part I'm
hoping will be relatively uncontroversial; that's in the first two commits.

The more unusual part of this PR: if you set the alternate format flag, a
`Style` will print its reset code, instead.

The combination of the two makes it easy to use inline formats to render
styles. Here's an example of how this looks:

```rust
use anstyle::{AnsiColor, Style};

fn main() {
    const RB: Style = AnsiColor::Red.on_default().bold();
    const GU: Style = AnsiColor::Green.on_default().underline();
    println!("{RB}Hello{RB:#}, {GU}world{GU:#}!");
}
```

I'm hoping this seems reasonable. If you find the use of the alternate flag too
much, though, then as an alternative, you could drop the last two commits, and
that would still let people render codes and resets using inline styles:

```rust
use anstyle::{AnsiColor, Reset, Style};

fn main() {
    const RESET: Reset = Reset;
    const RB: Style = AnsiColor::Red.on_default().bold();
    const GU: Style = AnsiColor::Green.on_default().underline();
    println!("{RB}Hello{RESET}, {GU}world{RESET}!");
}
```

(This would get even easier if anstyle had a `pub const RESET: Reset = Reset;`,
which I'd be happy to send in a patch for.)
