### PR TITLE
fix(anstyle): Don't display with formatter's settings 

### DIFF
--- a/crates/anstyle/src/color.rs
+++ b/crates/anstyle/src/color.rs
@@ -631,4 +631,30 @@ mod test {
         dbg!(size_of::<RgbColor>());
         dbg!(size_of::<DisplayBuffer>());
     }
+
+    #[test]
+    fn no_align() {
+        #[track_caller]
+        fn assert_align(d: impl core::fmt::Display) {
+            let expected = format!("{d:<10}");
+            let actual = format!("{d:<10}");
+            assert_eq!(expected, actual);
+        }
+
+        #[track_caller]
+        fn assert_no_align(d: impl core::fmt::Display) {
+            let expected = format!("{d}");
+            let actual = format!("{d:<10}");
+            assert_eq!(expected, actual);
+        }
+
+        assert_align(AnsiColor::White.render_fg());
+        assert_align(AnsiColor::White.render_bg());
+        assert_no_align(Ansi256Color(0).render_fg());
+        assert_no_align(Ansi256Color(0).render_bg());
+        assert_no_align(RgbColor(0, 0, 0).render_fg());
+        assert_no_align(RgbColor(0, 0, 0).render_bg());
+        assert_align(Color::Ansi(AnsiColor::White).render_fg());
+        assert_align(Color::Ansi(AnsiColor::White).render_bg());
+    }
 }

--- a/crates/anstyle/src/effect.rs
+++ b/crates/anstyle/src/effect.rs
@@ -314,7 +314,8 @@ impl core::fmt::Display for EffectsDisplay {
     #[inline]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         for index in self.0.index_iter() {
-            METADATA[index].escape.fmt(f)?;
+            let escape = METADATA[index].escape;
+            write!(f, "{escape}")?;
         }
         Ok(())
     }
@@ -383,12 +384,12 @@ mod test {
     #[test]
     fn no_align() {
         #[track_caller]
-        fn assert_align(d: impl core::fmt::Display) {
-            let expected = format!("{d:<10}");
+        fn assert_no_align(d: impl core::fmt::Display) {
+            let expected = format!("{d}");
             let actual = format!("{d:<10}");
             assert_eq!(expected, actual);
         }
 
-        assert_align(Effects::BOLD.render());
+        assert_no_align(Effects::BOLD.render());
     }
 }

--- a/crates/anstyle/src/effect.rs
+++ b/crates/anstyle/src/effect.rs
@@ -368,9 +368,27 @@ impl Iterator for EffectIndexIter {
     }
 }
 
-#[test]
-fn print_size_of() {
-    use std::mem::size_of;
-    dbg!(size_of::<Effects>());
-    dbg!(size_of::<EffectsDisplay>());
+#[cfg(test)]
+#[cfg(feature = "std")]
+mod test {
+    use super::*;
+
+    #[test]
+    fn print_size_of() {
+        use std::mem::size_of;
+        dbg!(size_of::<Effects>());
+        dbg!(size_of::<EffectsDisplay>());
+    }
+
+    #[test]
+    fn no_align() {
+        #[track_caller]
+        fn assert_align(d: impl core::fmt::Display) {
+            let expected = format!("{d:<10}");
+            let actual = format!("{d:<10}");
+            assert_eq!(expected, actual);
+        }
+
+        assert_align(Effects::BOLD.render());
+    }
 }

--- a/crates/anstyle/src/reset.rs
+++ b/crates/anstyle/src/reset.rs
@@ -20,8 +20,27 @@ impl core::fmt::Display for Reset {
 
 pub(crate) const RESET: &str = "\x1B[0m";
 
-#[test]
-fn print_size_of() {
-    use std::mem::size_of;
-    dbg!(size_of::<Reset>());
+#[cfg(test)]
+#[cfg(feature = "std")]
+mod test {
+    use super::*;
+
+    #[test]
+    fn print_size_of() {
+        use std::mem::size_of;
+        dbg!(size_of::<Reset>());
+    }
+
+    #[test]
+    fn no_align() {
+        #[track_caller]
+        fn assert_align(d: impl core::fmt::Display) {
+            let expected = format!("{d:<10}");
+            let actual = format!("{d:<10}");
+            assert_eq!(expected, actual);
+        }
+
+        assert_align(Reset);
+        assert_align(Reset.render());
+    }
 }

--- a/crates/anstyle/src/reset.rs
+++ b/crates/anstyle/src/reset.rs
@@ -14,7 +14,7 @@ impl Reset {
 
 impl core::fmt::Display for Reset {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        RESET.fmt(f)
+        write!(f, "{RESET}")
     }
 }
 
@@ -34,13 +34,13 @@ mod test {
     #[test]
     fn no_align() {
         #[track_caller]
-        fn assert_align(d: impl core::fmt::Display) {
-            let expected = format!("{d:<10}");
+        fn assert_no_align(d: impl core::fmt::Display) {
+            let expected = format!("{d}");
             let actual = format!("{d:<10}");
             assert_eq!(expected, actual);
         }
 
-        assert_align(Reset);
-        assert_align(Reset.render());
+        assert_no_align(Reset);
+        assert_no_align(Reset.render());
     }
 }


### PR DESCRIPTION
Before, we were inconsistent about this.  Now, we err on the side of
always ignoring the settings as there isn't really much reason to pad
ansi escape codes and the padding could accumulate over multiple calls.