### PR TITLE
fix(stream): Give NO_COLOR higher precedence 

### DIFF
--- a/crates/anstream/src/auto.rs
+++ b/crates/anstream/src/auto.rs
@@ -190,13 +190,16 @@ fn choice(raw: &dyn RawStream) -> ColorChoice {
             let clicolor = anstyle_query::clicolor();
             let clicolor_enabled = clicolor.unwrap_or(false);
             let clicolor_disabled = !clicolor.unwrap_or(true);
-            if raw.is_terminal()
-                && !anstyle_query::no_color()
-                && !clicolor_disabled
+            if anstyle_query::clicolor_force() {
+                ColorChoice::Always
+            } else if anstyle_query::no_color() {
+                ColorChoice::Never
+            } else if clicolor_disabled {
+                ColorChoice::Never
+            } else if raw.is_terminal()
                 && (anstyle_query::term_supports_color()
                     || clicolor_enabled
                     || anstyle_query::is_ci())
-                || anstyle_query::clicolor_force()
             {
                 ColorChoice::Always
             } else {

--- a/crates/anstream/src/auto.rs
+++ b/crates/anstream/src/auto.rs
@@ -190,10 +190,10 @@ fn choice(raw: &dyn RawStream) -> ColorChoice {
             let clicolor = anstyle_query::clicolor();
             let clicolor_enabled = clicolor.unwrap_or(false);
             let clicolor_disabled = !clicolor.unwrap_or(true);
-            if anstyle_query::clicolor_force() {
-                ColorChoice::Always
-            } else if anstyle_query::no_color() {
+            if anstyle_query::no_color() {
                 ColorChoice::Never
+            } else if anstyle_query::clicolor_force() {
+                ColorChoice::Always
             } else if clicolor_disabled {
                 ColorChoice::Never
             } else if raw.is_terminal()


### PR DESCRIPTION
This doesn't solve all problems
- Likely the CI check should be independent of `is_terminal` (since CI doesn't run with a pseudo tty
- We haven't dropped `CLICOLOR`
- We are still reading values for the env variables, rather than just checking presence, but this allows easier way to override values

Fixes #178