### PR TITLE
feat: Implement RawStream for more types

### DIFF
--- a/crates/anstream/src/buffer.rs
+++ b/crates/anstream/src/buffer.rs
@@ -54,15 +54,3 @@ impl anstyle_wincon::WinconStream for Buffer {
         self.0.write_colored(fg, bg, data)
     }
 }
-
-#[cfg(all(windows, feature = "wincon"))]
-impl anstyle_wincon::WinconStream for &'_ mut Buffer {
-    fn write_colored(
-        &mut self,
-        fg: Option<anstyle::AnsiColor>,
-        bg: Option<anstyle::AnsiColor>,
-        data: &[u8],
-    ) -> std::io::Result<usize> {
-        (**self).write_colored(fg, bg, data)
-    }
-}

--- a/crates/anstyle-wincon/src/ansi.rs
+++ b/crates/anstyle-wincon/src/ansi.rs
@@ -1,7 +1,7 @@
 //! Low-level ANSI-styling
 
 /// Write ANSI colored text to the stream
-pub fn write_colored<S: std::io::Write>(
+pub fn write_colored<S: std::io::Write + ?Sized>(
     stream: &mut S,
     fg: Option<anstyle::AnsiColor>,
     bg: Option<anstyle::AnsiColor>,


### PR DESCRIPTION
Closes https://github.com/rust-cli/anstyle/issues/220.

Implements `RawStream` (and the other required traits) for `&mut impl RawStream`, `Box<impl RawStream>`, `dyn std::io::Write {,+ Send {,+ Sync}}`.