### PR TITLE
refactor: Implement `RawStream` for `&mut T` and `Box<T>` generically

### DIFF
--- a/crates/anstream/src/buffer.rs
+++ b/crates/anstream/src/buffer.rs
@@ -54,15 +54,3 @@ impl anstyle_wincon::WinconStream for Buffer {
         self.0.write_colored(fg, bg, data)
     }
 }
-
-#[cfg(all(windows, feature = "wincon"))]
-impl anstyle_wincon::WinconStream for &'_ mut Buffer {
-    fn write_colored(
-        &mut self,
-        fg: Option<anstyle::AnsiColor>,
-        bg: Option<anstyle::AnsiColor>,
-        data: &[u8],
-    ) -> std::io::Result<usize> {
-        (**self).write_colored(fg, bg, data)
-    }
-}

--- a/crates/anstream/src/stream.rs
+++ b/crates/anstream/src/stream.rs
@@ -12,6 +12,7 @@ pub trait RawStream:
 }
 
 impl<T: RawStream + ?Sized> RawStream for &mut T {}
+impl<T: RawStream + ?Sized> RawStream for Box<T> {}
 
 impl RawStream for std::io::Stdout {}
 
@@ -21,7 +22,7 @@ impl RawStream for std::io::Stderr {}
 
 impl RawStream for std::io::StderrLock<'_> {}
 
-impl RawStream for Box<dyn std::io::Write> {}
+impl RawStream for dyn std::io::Write {}
 
 impl RawStream for Vec<u8> {}
 
@@ -44,6 +45,13 @@ impl<T: IsTerminal + ?Sized> IsTerminal for &T {
 }
 
 impl<T: IsTerminal + ?Sized> IsTerminal for &mut T {
+    #[inline]
+    fn is_terminal(&self) -> bool {
+        (**self).is_terminal()
+    }
+}
+
+impl<T: IsTerminal + ?Sized> IsTerminal for Box<T> {
     #[inline]
     fn is_terminal(&self) -> bool {
         (**self).is_terminal()
@@ -78,7 +86,7 @@ impl IsTerminal for std::io::StderrLock<'_> {
     }
 }
 
-impl IsTerminal for Box<dyn std::io::Write> {
+impl IsTerminal for dyn std::io::Write {
     #[inline]
     fn is_terminal(&self) -> bool {
         false
@@ -154,7 +162,7 @@ impl AsLockedWrite for std::io::StderrLock<'static> {
     }
 }
 
-impl AsLockedWrite for Box<dyn std::io::Write> {
+impl AsLockedWrite for dyn std::io::Write {
     type Write<'w> = &'w mut Self;
 
     #[inline]
@@ -196,6 +204,7 @@ mod private {
 
     impl<T: Sealed + ?Sized> Sealed for &T {}
     impl<T: Sealed + ?Sized> Sealed for &mut T {}
+    impl<T: Sealed + ?Sized> Sealed for Box<T> {}
 
     impl Sealed for std::io::Stdout {}
 
@@ -205,7 +214,7 @@ mod private {
 
     impl Sealed for std::io::StderrLock<'_> {}
 
-    impl Sealed for Box<dyn std::io::Write> {}
+    impl Sealed for dyn std::io::Write {}
 
     impl Sealed for Vec<u8> {}
 

--- a/crates/anstream/src/stream.rs
+++ b/crates/anstream/src/stream.rs
@@ -11,40 +11,43 @@ pub trait RawStream:
 {
 }
 
+impl<T: RawStream + ?Sized> RawStream for &mut T {}
+
 impl RawStream for std::io::Stdout {}
 
 impl RawStream for std::io::StdoutLock<'_> {}
-
-impl RawStream for &'_ mut std::io::StdoutLock<'_> {}
 
 impl RawStream for std::io::Stderr {}
 
 impl RawStream for std::io::StderrLock<'_> {}
 
-impl RawStream for &'_ mut std::io::StderrLock<'_> {}
-
 impl RawStream for Box<dyn std::io::Write> {}
-
-impl RawStream for &'_ mut Box<dyn std::io::Write> {}
 
 impl RawStream for Vec<u8> {}
 
-impl RawStream for &'_ mut Vec<u8> {}
-
 impl RawStream for std::fs::File {}
-
-impl RawStream for &'_ mut std::fs::File {}
 
 #[allow(deprecated)]
 impl RawStream for crate::Buffer {}
-
-#[allow(deprecated)]
-impl RawStream for &'_ mut crate::Buffer {}
 
 /// Trait to determine if a descriptor/handle refers to a terminal/tty.
 pub trait IsTerminal: private::Sealed {
     /// Returns `true` if the descriptor/handle refers to a terminal/tty.
     fn is_terminal(&self) -> bool;
+}
+
+impl<T: IsTerminal + ?Sized> IsTerminal for &T {
+    #[inline]
+    fn is_terminal(&self) -> bool {
+        (**self).is_terminal()
+    }
+}
+
+impl<T: IsTerminal + ?Sized> IsTerminal for &mut T {
+    #[inline]
+    fn is_terminal(&self) -> bool {
+        (**self).is_terminal()
+    }
 }
 
 impl IsTerminal for std::io::Stdout {
@@ -58,13 +61,6 @@ impl IsTerminal for std::io::StdoutLock<'_> {
     #[inline]
     fn is_terminal(&self) -> bool {
         is_terminal_polyfill::IsTerminal::is_terminal(self)
-    }
-}
-
-impl IsTerminal for &'_ mut std::io::StdoutLock<'_> {
-    #[inline]
-    fn is_terminal(&self) -> bool {
-        (**self).is_terminal()
     }
 }
 
@@ -82,21 +78,7 @@ impl IsTerminal for std::io::StderrLock<'_> {
     }
 }
 
-impl IsTerminal for &'_ mut std::io::StderrLock<'_> {
-    #[inline]
-    fn is_terminal(&self) -> bool {
-        (**self).is_terminal()
-    }
-}
-
 impl IsTerminal for Box<dyn std::io::Write> {
-    #[inline]
-    fn is_terminal(&self) -> bool {
-        false
-    }
-}
-
-impl IsTerminal for &'_ mut Box<dyn std::io::Write> {
     #[inline]
     fn is_terminal(&self) -> bool {
         false
@@ -110,24 +92,10 @@ impl IsTerminal for Vec<u8> {
     }
 }
 
-impl IsTerminal for &'_ mut Vec<u8> {
-    #[inline]
-    fn is_terminal(&self) -> bool {
-        false
-    }
-}
-
 impl IsTerminal for std::fs::File {
     #[inline]
     fn is_terminal(&self) -> bool {
         is_terminal_polyfill::IsTerminal::is_terminal(self)
-    }
-}
-
-impl IsTerminal for &'_ mut std::fs::File {
-    #[inline]
-    fn is_terminal(&self) -> bool {
-        (**self).is_terminal()
     }
 }
 
@@ -136,14 +104,6 @@ impl IsTerminal for crate::Buffer {
     #[inline]
     fn is_terminal(&self) -> bool {
         false
-    }
-}
-
-#[allow(deprecated)]
-impl IsTerminal for &'_ mut crate::Buffer {
-    #[inline]
-    fn is_terminal(&self) -> bool {
-        (**self).is_terminal()
     }
 }
 
@@ -234,33 +194,23 @@ impl AsLockedWrite for crate::Buffer {
 mod private {
     pub trait Sealed {}
 
+    impl<T: Sealed + ?Sized> Sealed for &T {}
+    impl<T: Sealed + ?Sized> Sealed for &mut T {}
+
     impl Sealed for std::io::Stdout {}
 
     impl Sealed for std::io::StdoutLock<'_> {}
-
-    impl Sealed for &'_ mut std::io::StdoutLock<'_> {}
 
     impl Sealed for std::io::Stderr {}
 
     impl Sealed for std::io::StderrLock<'_> {}
 
-    impl Sealed for &'_ mut std::io::StderrLock<'_> {}
-
     impl Sealed for Box<dyn std::io::Write> {}
-
-    impl Sealed for &'_ mut Box<dyn std::io::Write> {}
 
     impl Sealed for Vec<u8> {}
 
-    impl Sealed for &'_ mut Vec<u8> {}
-
     impl Sealed for std::fs::File {}
-
-    impl Sealed for &'_ mut std::fs::File {}
 
     #[allow(deprecated)]
     impl Sealed for crate::Buffer {}
-
-    #[allow(deprecated)]
-    impl Sealed for &'_ mut crate::Buffer {}
 }

--- a/crates/anstyle-wincon/src/ansi.rs
+++ b/crates/anstyle-wincon/src/ansi.rs
@@ -1,7 +1,7 @@
 //! Low-level ANSI-styling
 
 /// Write ANSI colored text to the stream
-pub fn write_colored<S: std::io::Write>(
+pub fn write_colored<S: std::io::Write + ?Sized>(
     stream: &mut S,
     fg: Option<anstyle::AnsiColor>,
     bg: Option<anstyle::AnsiColor>,

--- a/crates/anstyle-wincon/src/stream.rs
+++ b/crates/anstyle-wincon/src/stream.rs
@@ -9,6 +9,17 @@ pub trait WinconStream {
     ) -> std::io::Result<usize>;
 }
 
+impl<T: WinconStream + ?Sized> WinconStream for &mut T {
+    fn write_colored(
+        &mut self,
+        fg: Option<anstyle::AnsiColor>,
+        bg: Option<anstyle::AnsiColor>,
+        data: &[u8],
+    ) -> std::io::Result<usize> {
+        (**self).write_colored(fg, bg, data)
+    }
+}
+
 impl WinconStream for Box<dyn std::io::Write> {
     fn write_colored(
         &mut self,
@@ -17,17 +28,6 @@ impl WinconStream for Box<dyn std::io::Write> {
         data: &[u8],
     ) -> std::io::Result<usize> {
         crate::ansi::write_colored(self, fg, bg, data)
-    }
-}
-
-impl WinconStream for &'_ mut Box<dyn std::io::Write> {
-    fn write_colored(
-        &mut self,
-        fg: Option<anstyle::AnsiColor>,
-        bg: Option<anstyle::AnsiColor>,
-        data: &[u8],
-    ) -> std::io::Result<usize> {
-        (**self).write_colored(fg, bg, data)
     }
 }
 
@@ -42,17 +42,6 @@ impl WinconStream for std::fs::File {
     }
 }
 
-impl WinconStream for &'_ mut std::fs::File {
-    fn write_colored(
-        &mut self,
-        fg: Option<anstyle::AnsiColor>,
-        bg: Option<anstyle::AnsiColor>,
-        data: &[u8],
-    ) -> std::io::Result<usize> {
-        (**self).write_colored(fg, bg, data)
-    }
-}
-
 impl WinconStream for Vec<u8> {
     fn write_colored(
         &mut self,
@@ -61,17 +50,6 @@ impl WinconStream for Vec<u8> {
         data: &[u8],
     ) -> std::io::Result<usize> {
         crate::ansi::write_colored(self, fg, bg, data)
-    }
-}
-
-impl WinconStream for &'_ mut Vec<u8> {
-    fn write_colored(
-        &mut self,
-        fg: Option<anstyle::AnsiColor>,
-        bg: Option<anstyle::AnsiColor>,
-        data: &[u8],
-    ) -> std::io::Result<usize> {
-        (**self).write_colored(fg, bg, data)
     }
 }
 
@@ -148,27 +126,5 @@ mod platform {
             let initial = crate::windows::stderr_initial_colors();
             crate::windows::write_colored(self, fg, bg, data, initial)
         }
-    }
-}
-
-impl WinconStream for &'_ mut std::io::StdoutLock<'_> {
-    fn write_colored(
-        &mut self,
-        fg: Option<anstyle::AnsiColor>,
-        bg: Option<anstyle::AnsiColor>,
-        data: &[u8],
-    ) -> std::io::Result<usize> {
-        (**self).write_colored(fg, bg, data)
-    }
-}
-
-impl WinconStream for &'_ mut std::io::StderrLock<'_> {
-    fn write_colored(
-        &mut self,
-        fg: Option<anstyle::AnsiColor>,
-        bg: Option<anstyle::AnsiColor>,
-        data: &[u8],
-    ) -> std::io::Result<usize> {
-        (**self).write_colored(fg, bg, data)
     }
 }

--- a/crates/anstyle-wincon/src/stream.rs
+++ b/crates/anstyle-wincon/src/stream.rs
@@ -20,7 +20,18 @@ impl<T: WinconStream + ?Sized> WinconStream for &mut T {
     }
 }
 
-impl WinconStream for Box<dyn std::io::Write> {
+impl<T: WinconStream + ?Sized> WinconStream for Box<T> {
+    fn write_colored(
+        &mut self,
+        fg: Option<anstyle::AnsiColor>,
+        bg: Option<anstyle::AnsiColor>,
+        data: &[u8],
+    ) -> std::io::Result<usize> {
+        (**self).write_colored(fg, bg, data)
+    }
+}
+
+impl WinconStream for dyn std::io::Write {
     fn write_colored(
         &mut self,
         fg: Option<anstyle::AnsiColor>,


### PR DESCRIPTION
Implement `RawStream for &mut impl RawStream, Box<impl RawStream>` (and the other required traits) instead of implementing for each `&mut T`/`Box<T>` manually.

This includes existing implementations, plus the ones that were missing in certain cases and all future ones, so only new implementations are added.

Split from https://github.com/rust-cli/anstyle/pull/221.