### PR TITLE
feat: implement AutoStream for dyn Write + auto traits

### DIFF
--- a/crates/anstream/src/stream.rs
+++ b/crates/anstream/src/stream.rs
@@ -23,6 +23,8 @@ impl RawStream for std::io::Stderr {}
 impl RawStream for std::io::StderrLock<'_> {}
 
 impl RawStream for dyn std::io::Write {}
+impl RawStream for dyn std::io::Write + Send {}
+impl RawStream for dyn std::io::Write + Send + Sync {}
 
 impl RawStream for Vec<u8> {}
 
@@ -87,6 +89,20 @@ impl IsTerminal for std::io::StderrLock<'_> {
 }
 
 impl IsTerminal for dyn std::io::Write {
+    #[inline]
+    fn is_terminal(&self) -> bool {
+        false
+    }
+}
+
+impl IsTerminal for dyn std::io::Write + Send {
+    #[inline]
+    fn is_terminal(&self) -> bool {
+        false
+    }
+}
+
+impl IsTerminal for dyn std::io::Write + Send + Sync {
     #[inline]
     fn is_terminal(&self) -> bool {
         false
@@ -215,6 +231,8 @@ mod private {
     impl Sealed for std::io::StderrLock<'_> {}
 
     impl Sealed for dyn std::io::Write {}
+    impl Sealed for dyn std::io::Write + Send {}
+    impl Sealed for dyn std::io::Write + Send + Sync {}
 
     impl Sealed for Vec<u8> {}
 

--- a/crates/anstyle-wincon/src/stream.rs
+++ b/crates/anstyle-wincon/src/stream.rs
@@ -42,6 +42,28 @@ impl WinconStream for dyn std::io::Write {
     }
 }
 
+impl WinconStream for dyn std::io::Write + Send {
+    fn write_colored(
+        &mut self,
+        fg: Option<anstyle::AnsiColor>,
+        bg: Option<anstyle::AnsiColor>,
+        data: &[u8],
+    ) -> std::io::Result<usize> {
+        crate::ansi::write_colored(self, fg, bg, data)
+    }
+}
+
+impl WinconStream for dyn std::io::Write + Send + Sync {
+    fn write_colored(
+        &mut self,
+        fg: Option<anstyle::AnsiColor>,
+        bg: Option<anstyle::AnsiColor>,
+        data: &[u8],
+    ) -> std::io::Result<usize> {
+        crate::ansi::write_colored(self, fg, bg, data)
+    }
+}
+
 impl WinconStream for std::fs::File {
     fn write_colored(
         &mut self,


### PR DESCRIPTION
~~Based on #223. Only the last commit is from this PR.~~

Closes #220.

Implements `RawStream` (and the other required traits) for `dyn Write + Send {,+ Sync}`.