### PR TITLE
perf: avoid using write! macro with single `str`

### DIFF
--- a/crates/anstyle/src/color.rs
+++ b/crates/anstyle/src/color.rs
@@ -627,19 +627,17 @@ impl DisplayBuffer {
 impl core::fmt::Display for DisplayBuffer {
     #[inline]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let s = self.as_str();
-        write!(f, "{s}")
+        f.write_str(self.as_str())
     }
 }
 
 #[derive(Copy, Clone, Default, Debug)]
-struct NullFormatter<D: core::fmt::Display>(D);
+struct NullFormatter(&'static str);
 
-impl<D: core::fmt::Display> core::fmt::Display for NullFormatter<D> {
+impl core::fmt::Display for NullFormatter {
     #[inline]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let d = &self.0;
-        write!(f, "{d}")
+        f.write_str(self.0)
     }
 }
 

--- a/crates/anstyle/src/effect.rs
+++ b/crates/anstyle/src/effect.rs
@@ -323,8 +323,7 @@ impl core::fmt::Display for EffectsDisplay {
     #[inline]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         for index in self.0.index_iter() {
-            let escape = METADATA[index].escape;
-            write!(f, "{escape}")?;
+            f.write_str(METADATA[index].escape)?;
         }
         Ok(())
     }

--- a/crates/anstyle/src/reset.rs
+++ b/crates/anstyle/src/reset.rs
@@ -15,7 +15,7 @@ impl Reset {
 
 impl core::fmt::Display for Reset {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{RESET}")
+        f.write_str(RESET)
     }
 }
 


### PR DESCRIPTION
A known issue with `write!` is that it's slower and generates more code that direct calls to `write_str`, unfortunately even on the simple case of `"{str}"`. See https://github.com/rust-lang/rust/issues/76490.

I've verified with Godbolt that it is still the case: https://godbolt.org/z/sq3M8xWfo