### PR TITLE
Restore compatibility with windows-sys 0.52

### DIFF
--- a/crates/anstream/src/wincon.rs
+++ b/crates/anstream/src/wincon.rs
@@ -41,6 +41,7 @@ where
     S: anstyle_wincon::WinconStream,
     S: IsTerminal,
 {
+    /// Returns `true` if the descriptor/handle refers to a terminal/tty.
     #[inline]
     pub fn is_terminal(&self) -> bool {
         self.raw.is_terminal()

--- a/crates/anstyle-query/Cargo.toml
+++ b/crates/anstyle-query/Cargo.toml
@@ -24,7 +24,7 @@ pre-release-replacements = [
 ]
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59.0", features = ["Win32_System_Console", "Win32_Foundation"] }
+windows-sys = { version = ">=0.52.0, <=0.59.*", features = ["Win32_System_Console", "Win32_Foundation"] }
 
 [lints]
 workspace = true

--- a/crates/anstyle-query/src/windows.rs
+++ b/crates/anstyle-query/src/windows.rs
@@ -11,13 +11,13 @@ mod windows_console {
 
     fn enable_vt(handle: RawHandle) -> std::io::Result<()> {
         unsafe {
-            let handle: HANDLE = std::mem::transmute(handle);
             if handle.is_null() {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::BrokenPipe,
                     "console is detached",
                 ));
             }
+            let handle: HANDLE = std::mem::transmute(handle);
 
             let mut dwmode: CONSOLE_MODE = 0;
             if windows_sys::Win32::System::Console::GetConsoleMode(handle, &mut dwmode) == 0 {

--- a/crates/anstyle-query/src/windows.rs
+++ b/crates/anstyle-query/src/windows.rs
@@ -17,7 +17,7 @@ mod windows_console {
                     "console is detached",
                 ));
             }
-            let handle: HANDLE = std::mem::transmute(handle);
+            let handle: HANDLE = handle as HANDLE;
 
             let mut dwmode: CONSOLE_MODE = 0;
             if windows_sys::Win32::System::Console::GetConsoleMode(handle, &mut dwmode) == 0 {
@@ -33,7 +33,7 @@ mod windows_console {
         }
     }
 
-    pub fn enable_virtual_terminal_processing() -> std::io::Result<()> {
+    pub(crate) fn enable_virtual_terminal_processing() -> std::io::Result<()> {
         let stdout = std::io::stdout();
         let stdout_handle = stdout.as_raw_handle();
         let stderr = std::io::stderr();
@@ -72,7 +72,7 @@ pub fn enable_ansi_colors() -> Option<bool> {
     windows_console::enable_ansi_colors()
 }
 
-/// Raw ENABLE_VIRTUAL_TERMINAL_PROCESSING on stdout/stderr
+/// Raw `ENABLE_VIRTUAL_TERMINAL_PROCESSING` on stdout/stderr
 #[cfg(windows)]
 pub fn enable_virtual_terminal_processing() -> std::io::Result<()> {
     windows_console::enable_virtual_terminal_processing()

--- a/crates/anstyle-wincon/Cargo.toml
+++ b/crates/anstyle-wincon/Cargo.toml
@@ -32,7 +32,7 @@ anstyle = { version = "1.0.0", path = "../anstyle" }
 lexopt = "0.3.0"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59.0", features = ["Win32_System_Console", "Win32_Foundation"] }
+windows-sys = { version = ">=0.52.0, <=0.59.*", features = ["Win32_System_Console", "Win32_Foundation"] }
 
 [lints]
 workspace = true

--- a/crates/anstyle-wincon/examples/set-wincon.rs
+++ b/crates/anstyle-wincon/examples/set-wincon.rs
@@ -18,8 +18,9 @@ fn main() -> Result<(), lexopt::Error> {
     let fg = args.fg.and_then(|c| c.into_ansi());
     let bg = args.bg.and_then(|c| c.into_ansi());
 
-    let _ = stdout.write_colored(fg, bg, "".as_bytes());
+    let _ = stdout.write_colored(fg, bg, b"");
 
+    #[allow(clippy::mem_forget)]
     std::mem::forget(stdout);
 
     Ok(())

--- a/crates/anstyle-wincon/src/windows.rs
+++ b/crates/anstyle-wincon/src/windows.rs
@@ -129,10 +129,10 @@ mod inner {
         handle: RawHandle,
     ) -> Result<CONSOLE_SCREEN_BUFFER_INFO, IoError> {
         unsafe {
-            let handle: HANDLE = std::mem::transmute(handle);
             if handle.is_null() {
                 return Err(IoError::BrokenPipe);
             }
+            let handle: HANDLE = std::mem::transmute(handle);
 
             let mut info: CONSOLE_SCREEN_BUFFER_INFO = std::mem::zeroed();
             if windows_sys::Win32::System::Console::GetConsoleScreenBufferInfo(handle, &mut info)
@@ -150,10 +150,10 @@ mod inner {
         attributes: CONSOLE_CHARACTER_ATTRIBUTES,
     ) -> Result<(), IoError> {
         unsafe {
-            let handle: HANDLE = std::mem::transmute(handle);
             if handle.is_null() {
                 return Err(IoError::BrokenPipe);
             }
+            let handle: HANDLE = std::mem::transmute(handle);
 
             if windows_sys::Win32::System::Console::SetConsoleTextAttribute(handle, attributes) != 0
             {

--- a/crates/anstyle-wincon/src/windows.rs
+++ b/crates/anstyle-wincon/src/windows.rs
@@ -9,19 +9,13 @@ type StdioColorInnerResult = Result<(anstyle::AnsiColor, anstyle::AnsiColor), in
 /// Cached [`get_colors`] call for [`std::io::stdout`]
 pub fn stdout_initial_colors() -> StdioColorResult {
     static INITIAL: std::sync::OnceLock<StdioColorInnerResult> = std::sync::OnceLock::new();
-    INITIAL
-        .get_or_init(|| get_colors_(&std::io::stdout()))
-        .clone()
-        .map_err(Into::into)
+    (*INITIAL.get_or_init(|| get_colors_(&std::io::stdout()))).map_err(Into::into)
 }
 
 /// Cached [`get_colors`] call for [`std::io::stderr`]
 pub fn stderr_initial_colors() -> StdioColorResult {
     static INITIAL: std::sync::OnceLock<StdioColorInnerResult> = std::sync::OnceLock::new();
-    INITIAL
-        .get_or_init(|| get_colors_(&std::io::stderr()))
-        .clone()
-        .map_err(Into::into)
+    (*INITIAL.get_or_init(|| get_colors_(&std::io::stderr()))).map_err(Into::into)
 }
 
 /// Apply colors to future writes
@@ -132,7 +126,7 @@ mod inner {
             if handle.is_null() {
                 return Err(IoError::BrokenPipe);
             }
-            let handle: HANDLE = std::mem::transmute(handle);
+            let handle: HANDLE = handle as HANDLE;
 
             let mut info: CONSOLE_SCREEN_BUFFER_INFO = std::mem::zeroed();
             if windows_sys::Win32::System::Console::GetConsoleScreenBufferInfo(handle, &mut info)
@@ -153,7 +147,7 @@ mod inner {
             if handle.is_null() {
                 return Err(IoError::BrokenPipe);
             }
-            let handle: HANDLE = std::mem::transmute(handle);
+            let handle: HANDLE = handle as HANDLE;
 
             if windows_sys::Win32::System::Console::SetConsoleTextAttribute(handle, attributes) != 0
             {
@@ -258,7 +252,7 @@ mod inner {
         for expected in COLORS {
             let nibble = to_nibble(expected);
             let actual = from_nibble(nibble);
-            assert_eq!(expected, actual, "Intermediate: {}", nibble);
+            assert_eq!(expected, actual, "Intermediate: {nibble}");
         }
     }
 }


### PR DESCRIPTION
windows-sys 0.59 has been out for half a year, but a good chunk of the ecosystem hasn't fully moved off 0.52 yet. In fact, crates.io still reports slightly higher daily download numbers for 0.52 than for 0.59 up to this day. This often leads to larger workspaces pulling in both versions. [Some libraries](https://crates.io/crates/windows-sys/reverse_dependencies) that can easily remain compatible with both versions are mitigating this by relaxing their version requirements, making it easier to stay exclusively on 0.52 until all transitive dependencies are compatible with 0.59.

It turns out that anstyle-{query,wincon} can also be made compatible with both versions, see first commit for the details.

The second commit fixes accumulated clippy warnings in windows-specific code. I guess the clippy job in CI only runs on Linux and people rarely touch this code?

Similarly, I think the compatibility with windows-sys 0.52 won't be tested in CI because the minimal-versions job only runs on Linux. I did test it manually.