### PR TITLE
move to std once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,6 @@ version = "3.0.7"
 dependencies = [
  "anstyle 1.0.10",
  "lexopt",
- "once_cell",
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 repository = "https://github.com/rust-cli/anstyle.git"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.66.0"  # MSRV
+rust-version = "1.80.0"  # MSRV
 include = [
   "build.rs",
   "src/**/*",

--- a/crates/anstyle-wincon/Cargo.toml
+++ b/crates/anstyle-wincon/Cargo.toml
@@ -33,7 +33,6 @@ lexopt = "0.3.0"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59.0", features = ["Win32_System_Console", "Win32_Foundation"] }
-once_cell = "1.20.2"
 
 [lints]
 workspace = true

--- a/crates/anstyle-wincon/src/windows.rs
+++ b/crates/anstyle-wincon/src/windows.rs
@@ -2,22 +2,22 @@
 
 use std::os::windows::io::AsHandle;
 use std::os::windows::io::AsRawHandle;
+use std::sync::LazyLock;
 
 type StdioColorResult = std::io::Result<(anstyle::AnsiColor, anstyle::AnsiColor)>;
 type StdioColorInnerResult = Result<(anstyle::AnsiColor, anstyle::AnsiColor), inner::IoError>;
 
+static STOUT_COLORS: LazyLock<StdioColorInnerResult>  = LazyLock::new(|| get_colors_(&std::io::stdout()));
+static STERR_COLORS: LazyLock<StdioColorInnerResult>  = LazyLock::new(|| get_colors_(&std::io::stderr()));
+
 /// Cached [`get_colors`] call for [`std::io::stdout`]
 pub fn stdout_initial_colors() -> StdioColorResult {
-    static INITIAL: once_cell::sync::OnceCell<StdioColorInnerResult> =
-        once_cell::sync::OnceCell::new();
-    (*INITIAL.get_or_init(|| get_colors_(&std::io::stdout()))).map_err(Into::into)
+    STOUT_COLORS.map_err(Into::into)
 }
 
 /// Cached [`get_colors`] call for [`std::io::stderr`]
 pub fn stderr_initial_colors() -> StdioColorResult {
-    static INITIAL: once_cell::sync::OnceCell<StdioColorInnerResult> =
-        once_cell::sync::OnceCell::new();
-    (*INITIAL.get_or_init(|| get_colors_(&std::io::stderr()))).map_err(Into::into)
+    STERR_COLORS.map_err(Into::into)
 }
 
 /// Apply colors to future writes


### PR DESCRIPTION
This would bump the MSRV to 1.80.0 to remove the once_cell dependency.

As of 1.80, the lazy mechanism here can be replaced by an actual std LazyLock