### PR TITLE
refactor: Avoid once_cell on new Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ version = "3.0.7"
 dependencies = [
  "anstyle 1.0.10",
  "lexopt",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -613,6 +613,15 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ecf5dec444661aad892044dfcc6ea9b2d1be3db6c78916b91bbf9d903fc3006"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "owo-colors"

--- a/crates/anstyle-wincon/Cargo.toml
+++ b/crates/anstyle-wincon/Cargo.toml
@@ -33,7 +33,7 @@ lexopt = "0.3.0"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59.0", features = ["Win32_System_Console", "Win32_Foundation"] }
-once_cell = "1.20.2"
+once_cell_polyfill = "1.56.0"
 
 [lints]
 workspace = true

--- a/crates/anstyle-wincon/src/windows.rs
+++ b/crates/anstyle-wincon/src/windows.rs
@@ -8,15 +8,15 @@ type StdioColorInnerResult = Result<(anstyle::AnsiColor, anstyle::AnsiColor), in
 
 /// Cached [`get_colors`] call for [`std::io::stdout`]
 pub fn stdout_initial_colors() -> StdioColorResult {
-    static INITIAL: once_cell::sync::OnceCell<StdioColorInnerResult> =
-        once_cell::sync::OnceCell::new();
+    static INITIAL: once_cell_polyfill::sync::OnceLock<StdioColorInnerResult> =
+        once_cell_polyfill::sync::OnceLock::new();
     (*INITIAL.get_or_init(|| get_colors_(&std::io::stdout()))).map_err(Into::into)
 }
 
 /// Cached [`get_colors`] call for [`std::io::stderr`]
 pub fn stderr_initial_colors() -> StdioColorResult {
-    static INITIAL: once_cell::sync::OnceCell<StdioColorInnerResult> =
-        once_cell::sync::OnceCell::new();
+    static INITIAL: once_cell_polyfill::sync::OnceLock<StdioColorInnerResult> =
+        once_cell_polyfill::sync::OnceLock::new();
     (*INITIAL.get_or_init(|| get_colors_(&std::io::stderr()))).map_err(Into::into)
 }
 


### PR DESCRIPTION
This supersedes #251