### PR TITLE
ci(cargo.toml): improve metadata with clarification

### DIFF
--- a/crates/anstream/Cargo.toml
+++ b/crates/anstream/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "anstream"
 version = "0.6.19"
-description = "A simple cross platform library for writing colored text to a terminal."
+description = "A simple cross platform library for writing (and auto-adapting) colored text to a terminal."
 categories = ["command-line-interface"]
 keywords = ["ansi", "terminal", "color", "strip", "wincon"]
 repository.workspace = true


### PR DESCRIPTION
### Proposed Change:

add verbage to make this repo more distinguishable from other crates like `color-print` whose description uses similar verbage:
> Colorize and stylize strings for terminal at compile-time, by using an HTML-like syntax

### Reasoning:

improves repository uniqueness for Software Analysis tools (and overall SEO) that do scans of https://crates.io/api/v1