### PR TITLE
fix: Ensuse rustfmt is installed for coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,7 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
+        components: rustfmt
     - uses: Swatinem/rust-cache@v2
     - name: Install cargo-tarpaulin
       run: cargo install cargo-tarpaulin


### PR DESCRIPTION
In #269, the [CI job for coverage failed](https://github.com/rust-cli/anstyle/actions/runs/18075332466/job/51430963932?pr=269) because it requires `rustfmt`, but it was not installed. This PR adds `rustfmt` to the `components` list of `dtolnay/rust-toolchain`, which should make it always get installed.