### PR TITLE
feat(anstream): Provide read-only access to inner stream

### DIFF
--- a/crates/anstream/src/auto.rs
+++ b/crates/anstream/src/auto.rs
@@ -157,6 +157,17 @@ where
         }
     }
 
+    /// Get the wrapped [`RawStream`]
+    #[inline]
+    pub fn as_inner(&self) -> &S {
+        match &self.inner {
+            StreamInner::PassThrough(w) => w,
+            StreamInner::Strip(w) => w.as_inner(),
+            #[cfg(all(windows, feature = "wincon"))]
+            StreamInner::Wincon(w) => w.as_inner(),
+        }
+    }
+
     /// Returns `true` if the descriptor/handle refers to a terminal/tty.
     #[inline]
     pub fn is_terminal(&self) -> bool {

--- a/crates/anstream/src/strip.rs
+++ b/crates/anstream/src/strip.rs
@@ -30,6 +30,12 @@ where
     pub fn into_inner(self) -> S {
         self.raw
     }
+
+    /// Get the wrapped [`std::io::Write`]
+    #[inline]
+    pub fn as_inner(&self) -> &S {
+        &self.raw
+    }
 }
 
 impl<S> StripStream<S>

--- a/crates/anstream/src/wincon.rs
+++ b/crates/anstream/src/wincon.rs
@@ -34,6 +34,12 @@ where
     pub fn into_inner(self) -> S {
         self.raw
     }
+
+    /// Get the wrapped [`std::io::Write`]
+    #[inline]
+    pub fn as_inner(&self) -> &S {
+        &self.raw
+    }
 }
 
 impl<S> WinconStream<S>


### PR DESCRIPTION
The main concern we have is `&mut Inner` because our processing of input is stateful and this can mess things up.
Adding an `as_inner` doesn't have that problem and can be useful for any custom behavior users have added that they want to query. This particularly came up with converting Rustup from termcolor to anstream because of their test stream.