### PR TITLE
Avoid using a version range for windows-sys; causes non-deterministic version resolution

### DIFF
--- a/crates/anstyle-query/Cargo.toml
+++ b/crates/anstyle-query/Cargo.toml
@@ -24,7 +24,7 @@ pre-release-replacements = [
 ]
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = ">=0.60.2, <0.62", features = ["Win32_System_Console", "Win32_Foundation"] }
+windows-sys = { version = "0.61", features = ["Win32_System_Console", "Win32_Foundation"] }
 
 [lints]
 workspace = true

--- a/crates/anstyle-wincon/Cargo.toml
+++ b/crates/anstyle-wincon/Cargo.toml
@@ -31,7 +31,7 @@ anstyle = { version = "1.0.0", path = "../anstyle" }
 lexopt = "0.3.1"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = ">=0.60.2, <0.62", features = ["Win32_System_Console", "Win32_Foundation"] }
+windows-sys = { version = "0.61", features = ["Win32_System_Console", "Win32_Foundation"] }
 once_cell_polyfill = "1.56.1"
 
 [lints]


### PR DESCRIPTION
Cargo's version resolver doesn't handle version ranges like this very well, resulting in non-deterministic flip-flopping of versions.

https://github.com/rust-lang/cargo/issues/9029
https://github.com/rust-lang/cargo/issues/5529
https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/Cargo.2Elock.20non-deterministically.20flipflopping/with/520024108
