### PR TITLE
feat(progress): Add support for KDE Konsole

### DIFF
--- a/crates/anstyle-progress/src/query.rs
+++ b/crates/anstyle-progress/src/query.rs
@@ -42,6 +42,17 @@ pub fn supports_term_progress(is_terminal: bool) -> bool {
         return true;
     }
 
+    // Konsole added support in 26.04.0.
+    // https://invent.kde.org/utilities/konsole/-/merge_requests/1054
+    let konsole = std::env::var("KONSOLE_VERSION")
+        .ok()
+        .and_then(|version| version.parse::<u32>().ok())
+        .map(|version| version >= 260400)
+        .unwrap_or(false);
+    if konsole {
+        return true;
+    }
+
     false
 }
 


### PR DESCRIPTION
Konsole added support for OSC 9;4 in version 26.04.0 from earlier this year.

https://invent.kde.org/utilities/konsole/-/merge_requests/1054

---

I couldn't find a public changelog, so I did a quick manual bisect to find the first Konsole git tag that included the commit from that PR.

v25.12.3 did not include it:
```
❯ git log v25.12.3 --grep 'Support ConEnmu progress OSC'  
```
v26.04.0 does:
```
❯ git log v26.04.0 --grep 'Support ConEnmu progress OSC'
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
commit da7a68a19714f16d69e4573de15a080e22ba9185 ┃
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
Author: Kai Uwe Broulik <kde@privat.broulik.de>
Date:   Tue Dec 23 19:11:15 2025 +0100

    Support ConEnmu progress OSC
    
    The 9;4 sequences can be used to show and hide progress on the tab bar.
    The error, indeterminate, and paused states are not implemented yet.
    
    If a tab has a custom color, its color is used for the progress, otherwise
    the standard highlight color is used.
    
    [1] https://conemu.github.io/en/AnsiEscapeCodes.html#ConEmu_specific_OSC
```

I've tested that things actually work on a Fedora 44 system running Konsole `konsole-26.04.3-1.fc44.x86_64`. The progress bar shows up in Konsole's tab bar as well as Konsole's icon in the desktop panel.